### PR TITLE
efitviewer-style diagnostic and hardware overlays as method of ODS

### DIFF
--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -460,11 +460,16 @@ def overlay(ods, ax=None, **kw):
     """
     if ax is None:
         ax = pyplot.gca()
-    supported_systems = ['gas_injection', 'thomson_scattering', 'bolometer']
-    for hw_sys in supported_systems:
-        if kw.get(hw_sys, False):
+    overlay_on_by_default = ['thomson_scattering']  # List of strings describing default hardware to be shown
+    for hw_sys in list_structures(ods.imas_version):
+        if kw.get(hw_sys, hw_sys in overlay_on_by_default):
             overlay_kw = kw.get(hw_sys, {}) if isinstance(kw.get(hw_sys, {}), dict) else {}
-            eval('{}_overlay'.format(hw_sys))(ods, ax, **overlay_kw)
+            try:
+                overlay_function = eval('{}_overlay'.format(hw_sys))
+            except NameError:
+                pass
+            else:
+                overlay_function(ods, ax, **overlay_kw)
     return
 
 

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -457,7 +457,7 @@ def overlay(ods, ax=None, **kw):
 
     :param ax: Axes instance or None
 
-    :param kw: select plots by setting their names to True; e.g.: if you want the gas_injection plot,
+    :param **kw: select plots by setting their names to True; e.g.: if you want the gas_injection plot,
         set gas_injection=True as a keyword.
         Instead of True to simply turn on an overlay, you can pass a dict of keywords to pass to a particular overlay
         method, as in thomson={'labelevery': 5}. After an overlay pops off its keywords, remaining keywords are passed
@@ -527,7 +527,7 @@ def gas_injection_overlay(ods, ax=None, angle_not_in_pipe_name=False, **kw):
         Set this to include (Angle) at the end of injector labels. Useful if injector/pipe names don't already include
         angles in them.
 
-    :param kw: Additional keywords for gas plot:
+    :param **kw: Additional keywords for gas plot:
         colors: List of colors for the various gas ports. The list will be repeated to make sure it is long enough.
             Do not specify a single RGB tuple by itself. However, a single tuple inside list is okay [(0.9, 0, 0, 0.9)]
         *Remaining keywords are passed to plot call for drawing markers at the gas locations.
@@ -576,6 +576,38 @@ def gas_injection_overlay(ods, ax=None, angle_not_in_pipe_name=False, **kw):
         gas_mark = ax.plot(r, z, marker=kw.pop('marker', 'd'), color=colors[i], **kw)
         ax.text(r, z, label, color=gas_mark[0].get_color(),
                 va=['top', 'bottom'][int(z > 0)], ha=['left', 'right'][int(r < rsplit)])
+    return
+
+
+@add_to__ODS__
+def interferometer_overlay(ods, ax=None, **kw):
+    """
+    Plots overlays of interferometer chords.
+
+    :param ods: OMAS ODS instance
+
+    :param ax: Axes instance
+
+    :param **kw: Additional keywords
+        *Remaining keywords are passed to plot call
+    """
+    # Make sure there is something to plot or else just give up and return
+    nc = get_channel_count(
+        ods, 'interferometer', check_loc='interferometer.channel.0.line_of_sight.first_point.r',
+        test_checker='checker > 0')
+    if nc == 0:
+        return
+
+    if ax is None:
+        ax = pyplot.gca()
+
+    for i in range(nc):
+        ch = ods['interferometer.channel'][i]
+        los = ch['line_of_sight']
+        r1, z1, r2, z2 = los['first_point.r'], los['first_point.z'], los['second_point.r'], los['second_point.z']
+        line = ax.plot([r1, r2], [z1, z2], **kw)
+        ax.text(min([r1, r2]), min([z1, z2]), ch['identifier'], color=line[0].get_color())
+
     return
 
 

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -449,13 +449,17 @@ def core_profiles_pressures(ods, time_index=0, ax=None, **kw):
 
 
 @add_to__ODS__
-def overlay(ods, ax=None, **kw):
+def overlay(ods, ax=None, allow_autoscale=True, **kw):
     """
     Plots overlays of hardware/diagnostic locations on a tokamak cross section plot
 
     :param ods: OMAS ODS instance
 
     :param ax: Axes instance or None
+
+    :param allow_autoscale: bool
+        Certain overlays will be allowed to unlock xlim and ylim, assuming that they have been locked by equilibrium_CX.
+        If this option is disabled, then hardware systems like PF-coils will be off the plot and mostly invisible.
 
     :param \**kw: select plots by setting their names to True; e.g.: if you want the gas_injection plot,
         set gas_injection=True as a keyword.
@@ -465,6 +469,7 @@ def overlay(ods, ax=None, **kw):
     """
     if ax is None:
         ax = pyplot.gca()
+
     overlay_on_by_default = ['thomson_scattering']  # List of strings describing default hardware to be shown
     for hw_sys in list_structures(ods.imas_version):
         if kw.get(hw_sys, hw_sys in overlay_on_by_default):
@@ -474,7 +479,11 @@ def overlay(ods, ax=None, **kw):
             except NameError:
                 pass
             else:
+                if allow_autoscale and hw_sys in ['pf_active']:  # Not all systems need expanded range to fit everything
+                    ax.set_xlim(auto=True)
+                    ax.set_ylim(auto=True)
                 overlay_function(ods, ax, **overlay_kw)
+
     return
 
 
@@ -718,7 +727,7 @@ def interferometer_overlay(ods, ax=None, **kw):
         r1, z1, r2, z2 = los['first_point.r'], los['first_point.z'], los['second_point.r'], los['second_point.z']
         line = ax.plot([r1, r2], [z1, z2], color=color, label='interferometer' if i == 0 else '', **kw)
         color = line[0].get_color()  # If this was None before, the cycler will have given us something. Lock it in.
-        ax.text(min([r1, r2]), min([z1, z2]), ch['identifier'], color=color)
+        ax.text(min([r1, r2]), min([z1, z2]), ch['identifier'], color=color, va='top', ha='left')
 
     return
 

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -457,7 +457,7 @@ def overlay(ods, ax=None, **kw):
 
     :param ax: Axes instance or None
 
-    :param **kw: select plots by setting their names to True; e.g.: if you want the gas_injection plot,
+    :param \**kw: select plots by setting their names to True; e.g.: if you want the gas_injection plot,
         set gas_injection=True as a keyword.
         Instead of True to simply turn on an overlay, you can pass a dict of keywords to pass to a particular overlay
         method, as in thomson={'labelevery': 5}. After an overlay pops off its keywords, remaining keywords are passed
@@ -527,7 +527,7 @@ def gas_injection_overlay(ods, ax=None, angle_not_in_pipe_name=False, **kw):
         Set this to include (Angle) at the end of injector labels. Useful if injector/pipe names don't already include
         angles in them.
 
-    :param **kw: Additional keywords for gas plot:
+    :param \**kw: Additional keywords for gas plot:
         colors: List of colors for the various gas ports. The list will be repeated to make sure it is long enough.
             Do not specify a single RGB tuple by itself. However, a single tuple inside list is okay [(0.9, 0, 0, 0.9)]
         *Remaining keywords are passed to plot call for drawing markers at the gas locations.
@@ -588,7 +588,7 @@ def interferometer_overlay(ods, ax=None, **kw):
 
     :param ax: Axes instance
 
-    :param **kw: Additional keywords
+    :param \**kw: Additional keywords
         *Remaining keywords are passed to plot call
     """
     # Make sure there is something to plot or else just give up and return
@@ -622,7 +622,7 @@ def thomson_scattering_overlay(ods, ax=None, **kw):
 
     :param ax: Axes instance
 
-    :param **kw: Additional keywords for Thomson plot:
+    :param \**kw: Additional keywords for Thomson plot:
         labelevery: int
             Sets how often to label channels. labelevery=1 can get crowded.
         mask: bool array with length matching number of channels in ods
@@ -657,7 +657,7 @@ def bolometer_overlay(ods, ax=None, **kw):
 
     :param ax: Axes instance
 
-    :param **kw: Additional keywords for bolometer plot
+    :param \**kw: Additional keywords for bolometer plot
         labelevery: int
             Sets how often to label channels.
         mask: bool array with length matching number of channels in ods

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -581,6 +581,50 @@ def gas_injection_overlay(ods, ax=None, angle_not_in_pipe_name=False, **kw):
 
 
 @add_to__ODS__
+def pf_active_overlay(ods, ax=None, **kw):
+    """
+    Plots overlays of interferometer chords.
+
+    :param ods: OMAS ODS instance
+
+    :param ax: Axes instance
+
+    :param \**kw: Additional keywords
+        *Remaining keywords are passed to plot call
+    """
+    # Make sure there is something to plot or else just give up and return
+    nc = get_channel_count(
+        ods, 'pf_active', check_loc='pf_active.coil.0.element.0.geometry.oblique.r', channels_name='coil',
+        test_checker='checker > 0')
+    if nc == 0:
+        return
+
+    if ax is None:
+        ax = pyplot.gca()
+
+    color = kw.pop('color', None)
+
+    for i in range(nc):  # From  iris:/fusion/usc/src/idl/efitview/diagnoses/DIII-D/coils.pro ,  2018 June 08  D. Eldon
+        oblique = ods['pf_active.coil'][i]['element.0.geometry.oblique']
+        fdat = [oblique['r'], oblique['z'], oblique['length'], oblique['thickness'], oblique['alpha'], oblique['beta']]
+
+        xarr = [fdat[0] - fdat[2] / 2. - fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5]),
+                fdat[0] - fdat[2] / 2. + fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5]),
+                fdat[0] + fdat[2] / 2. + fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5]),
+                fdat[0] + fdat[2] / 2. - fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5]),
+                fdat[0] - fdat[2] / 2. - fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5])]
+        yarr = [fdat[1] - fdat[3] / 2. - fdat[2] / 2. * numpy.tan(fdat[4]),
+                fdat[1] + fdat[3] / 2. - fdat[2] / 2. * numpy.tan(fdat[4]),
+                fdat[1] + fdat[3] / 2. + fdat[2] / 2. * numpy.tan(fdat[4]),
+                fdat[1] - fdat[3] / 2. + fdat[2] / 2. * numpy.tan(fdat[4]),
+                fdat[1] - fdat[3] / 2. - fdat[2] / 2. * numpy.tan(fdat[4])]
+        fcoil = ax.plot(xarr, yarr, color=color, **kw)
+        color = fcoil[0].get_color()  # If this was None before, the cycler will have given us something. Lock it in.
+
+    return
+
+
+@add_to__ODS__
 def magnetics_overlay(ods, ax=None, **kw):
     """
     Plots overlays of magnetics: B_pol probes and flux loops

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -601,12 +601,14 @@ def interferometer_overlay(ods, ax=None, **kw):
     if ax is None:
         ax = pyplot.gca()
 
+    color = kw.pop('color', None)
     for i in range(nc):
         ch = ods['interferometer.channel'][i]
         los = ch['line_of_sight']
         r1, z1, r2, z2 = los['first_point.r'], los['first_point.z'], los['second_point.r'], los['second_point.z']
-        line = ax.plot([r1, r2], [z1, z2], **kw)
-        ax.text(min([r1, r2]), min([z1, z2]), ch['identifier'], color=line[0].get_color())
+        line = ax.plot([r1, r2], [z1, z2], color=color, label='interferometer' if i == 0 else '', **kw)
+        color = line[0].get_color()  # If this was None before, the cycler will have given us something. Lock it in.
+        ax.text(min([r1, r2]), min([z1, z2]), ch['identifier'], color=color)
 
     return
 

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -460,19 +460,16 @@ def overlay(ods, ax=None, **kw):
     """
     if ax is None:
         ax = pyplot.gca()
-    if kw.pop('gas', False):
-        gas_overlay(ods, ax)
-    if kw.get('thomson', False):
-        tskw = kw.get('thomson', {}) if isinstance(kw.get('thomson', {}), dict) else {}
-        thomson_overlay(ods, ax, **tskw)
-    if kw.get('bolometer', False):
-        bolkw = kw.get('bolometer', {}) if isinstance(kw.get('bolometer', {}), dict) else {}
-        bolometer_overlay(ods, ax, **bolkw)
+    supported_systems = ['gas_injection', 'thomson_scattering', 'bolometer']
+    for hw_sys in supported_systems:
+        if kw.get(hw_sys, False):
+            overlay_kw = kw.get(hw_sys, {}) if isinstance(kw.get(hw_sys, {}), dict) else {}
+            eval('{}_overlay'.format(hw_sys))(ods, ax, **overlay_kw)
     return
 
 
 @add_to__ODS__
-def gas_overlay(ods, ax=None, angle_not_in_pipe_name=False):
+def gas_injection_overlay(ods, ax=None, angle_not_in_pipe_name=False):
     """
     Plots overlays of gas injectors
     :param ods: OMAS ODS instance
@@ -518,7 +515,7 @@ def gas_overlay(ods, ax=None, angle_not_in_pipe_name=False):
 
 
 @add_to__ODS__
-def thomson_overlay(ods, ax=None, **kw):
+def thomson_scattering_overlay(ods, ax=None, **kw):
     """
     Overlays Thomson channel locations
     :param ods: OMAS ODS instance

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -452,8 +452,11 @@ def core_profiles_pressures(ods, time_index=0, ax=None, **kw):
 def overlay(ods, ax=None, **kw):
     """
     Plots overlays of hardware/diagnostic locations on a tokamak cross section plot
+
     :param ods: OMAS ODS instance
+
     :param ax: Axes instance or None
+
     :param kw: select plots by setting their names to True; e.g.: if you want the gas_injection plot,
         set gas_injection=True as a keyword.
         Instead of True to simply turn on an overlay, you can pass a dict of keywords to pass to a particular overlay
@@ -479,16 +482,22 @@ def get_channel_count(ods, hw_sys, check_loc=None, test_checker=None, channels_n
     """
     Gets a channel count for some hardware sys. 0 indicates empty. Provide check_loc to make sure some data exist.
     Utility for CX hardware overlay functions.
+
     :param ods: OMAS ODS instance
+
     :param hw_sys: string describing the hardware system to check
+
     :param check_loc: [optional] string
         If provided, an additional check will be made to ensure that some data exist.
         If this check fails, channel count will be set to 0
+
     :param test_checker: [optional] string to evaluate into bool
         Like "checker > 0", where checker = ods[check_loc]. If this test fails, nc will be set to 0
+
     :param channels_name: string
         Use if you need to generalize to something that doesn't have real channels but has something analogous,
         like how gas_injection has 'pipe' that's shaped like 'channel' is in thomson_scattering.
+
     :return: Number of channels for this hardware system. 0 if there's trouble.
     """
     try:
@@ -509,11 +518,15 @@ def get_channel_count(ods, hw_sys, check_loc=None, test_checker=None, channels_n
 def gas_injection_overlay(ods, ax=None, angle_not_in_pipe_name=False, **kw):
     """
     Plots overlays of gas injectors
+
     :param ods: OMAS ODS instance
+
     :param ax: Axes instance
+
     :param angle_not_in_pipe_name: bool
         Set this to include (Angle) at the end of injector labels. Useful if injector/pipe names don't already include
         angles in them.
+
     :param kw: Additional keywords for gas plot:
         colors: List of colors for the various gas ports. The list will be repeated to make sure it is long enough.
             Do not specify a single RGB tuple by itself. However, a single tuple inside list is okay [(0.9, 0, 0, 0.9)]
@@ -570,9 +583,12 @@ def gas_injection_overlay(ods, ax=None, angle_not_in_pipe_name=False, **kw):
 def thomson_scattering_overlay(ods, ax=None, **kw):
     """
     Overlays Thomson channel locations
+
     :param ods: OMAS ODS instance
+
     :param ax: Axes instance
-    :param kw: Additional keywords for Thomson plot:
+
+    :param **kw: Additional keywords for Thomson plot:
         labelevery: int
             Sets how often to label channels. labelevery=1 can get crowded.
         mask: bool array with length matching number of channels in ods
@@ -602,9 +618,12 @@ def thomson_scattering_overlay(ods, ax=None, **kw):
 def bolometer_overlay(ods, ax=None, **kw):
     """
     Overlays bolometer chords
+
     :param ods: ODS instance
+
     :param ax: Axes instance
-    :param kw: Additional keywords for bolometer plot
+
+    :param **kw: Additional keywords for bolometer plot
         labelevery: int
             Sets how often to label channels.
         mask: bool array with length matching number of channels in ods

--- a/omas/omas_utils.py
+++ b/omas/omas_utils.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, unicode_literals
 from .omas_setup import *
 import sys
 
+
 # --------------------------
 # general utility functions
 # --------------------------
@@ -57,6 +58,21 @@ def is_uncertain(var):
         return numpy.reshape(tmp,numpy.array(var).shape)
     else:
         return _uncertain_check(var)
+
+
+def is_numeric(value):
+    """
+    Convenience function check if value is numeric
+
+    :param value: value to check
+
+    :return: True/False
+    """
+    try:
+        0+value
+        return True
+    except TypeError:
+        return False
 
 
 def json_dumper(obj):
@@ -238,6 +254,50 @@ def remove_parentheses(inv, replace_with=''):
     return out
 
 
+def closest_index(my_list, my_number=0):
+    """
+    Given a SORTED iterable (a numeric array or list of numbers) and a numeric scalar my_number, find the index of the
+    number in the list that is closest to my_number
+
+    :param my_list: Sorted iterable (list or array) to search for number closest to my_number
+
+    :param my_number: Number to get close to in my_list
+
+    :return: Index of my_list element closest to my_number
+
+    :note: If two numbers are equally close, returns the index of the smallest number.
+    """
+    import bisect
+
+    if not hasattr(my_list, '__iter__'):
+        raise TypeError("closestIndex() in utils_math.py requires an iterable as the first argument. Got "
+                        "instead: {:}".format(my_list))
+
+    if not is_numeric(my_number):
+        if hasattr(my_number, '__iter__') and len(my_number) == 1 and is_numeric(my_number[0]):
+            printw('Warning: closestIndex got a len()=1 iterable instead of a scalar for my_number. my_number[0] will '
+                   'be used, but please input a scalar next time.')
+            # Before, the function would run without an error if given a one element array, but it would not return the
+            # correct answer.
+            my_number = my_number[0]
+            printd('my_number is now {:}'.format(my_number))
+        else:
+            raise TypeError("closestIndex() in utils_math.py requires a numeric scalar as the second argument. Got "
+                            "instead: {:}".format(my_number))
+
+    pos = bisect.bisect_left(my_list, my_number)
+    if pos == 0:
+        return 0
+    if pos == len(my_list):
+        return pos-1
+    before = pos - 1
+    after = pos
+    if my_list[after] - my_number < my_number - my_list[before]:
+        return pos
+    else:
+        return pos-1
+
+
 # ----------------------------------------------
 # handling of OMAS json structures
 # ----------------------------------------------
@@ -251,6 +311,7 @@ _structures = {}
 _structures_dict = {}
 # similar to `_structures_dict` but for use in omas_info
 _info_structures = {}
+
 
 def list_structures(imas_version):
     return sorted(list(map(lambda x: os.path.splitext(os.path.split(x)[1])[0],
@@ -317,6 +378,7 @@ def p2l(key):
         except ValueError:
             pass
     return key
+
 
 def l2i(path):
     """


### PR DESCRIPTION
- ODS should be able to hold everything needed to make a tokamak cross section plot with overlays showing positions of various hardware systems
- OMFIT will provide utilities for loading minimal hardware info to enable these overlays; see gafusion/OMFIT-source#2791
- Overlays should also work fine on a fully developed and populated ODS
- Add diagnostic/hardware overlay plot to omas_plot
  - The master `overlay` function calls individual overlays depending on which are switched on
  - So far, the individual hardware systems with overlay methods are: Thomson, bolometers, and gas puffing
  - More hardware systems to be added later
- Add some utility functions in omas_utils

Changes needed/suggested (please edit as needed):
- [x] Individual hardware system overlays detect whether or not they have adequate data and abort themselves gracefully if they're missing something.
- [x] Generalize logic for choosing which overlays to call instead of giving each one of them its own `if`. See review by @smithsp .
- [x] More systems (I don't think all are needed to start with, but we should get all the essentials):
  - [x] CER overlay (with keywords to select which beams and view directions (tang vs vert))
  - [x] Magnetic probe overlay
  - [x] PF coil overlay
  - [x] Interferometer overlay
- [ ] Stress test custom keywords like `labelevery` and `mask`
- [ ] Final review and polish

![omas_efitviewer_cx](https://user-images.githubusercontent.com/15132846/41245450-e7d435d2-6d5c-11e8-8019-9f2a1984f4c4.png)
