### PR TITLE
PF coil and gas arrow plots use cocos_transform

### DIFF
--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -311,7 +311,7 @@ def gas_arrow(ods, r, z, direction=None, snap_to=numpy.pi/4.0, ax=None, color=No
         """Guesses the direction for the arrow (from injector toward machine) in case you don't know"""
         dr = ods['equilibrium']['time_slice'][0]['global_quantities']['magnetic_axis']['r'] - r
         dz = ods['equilibrium']['time_slice'][0]['global_quantities']['magnetic_axis']['z'] - z
-        theta = -numpy.arctan2(dz, -dr)
+        theta = numpy.arctan2(dz, -dr)
         if snap_to > 0:
             theta = snap_to * round(theta/snap_to)
         return theta
@@ -327,15 +327,15 @@ def gas_arrow(ods, r, z, direction=None, snap_to=numpy.pi/4.0, ax=None, color=No
     shaft_len = 3.5 * (1+pad)/2.
 
     da = numpy.pi/10  # Angular half width of the arrow head
-    x0 = numpy.cos(direction) * pad
-    y0 = numpy.sin(direction) * pad
+    x0 = numpy.cos(-direction) * pad
+    y0 = numpy.sin(-direction) * pad
     head_mark = [
         (x0, y0),
-        (x0+numpy.cos(direction+da), y0+numpy.sin(direction+da)),
-        (x0+numpy.cos(direction), y0+numpy.sin(direction)),
-        (x0+shaft_len*numpy.cos(direction), y0+shaft_len*numpy.sin(direction)),
-        (x0+numpy.cos(direction), y0+numpy.sin(direction)),
-        (x0+numpy.cos(direction-da), y0+numpy.sin(direction-da)),
+        (x0+numpy.cos(-direction+da), y0+numpy.sin(-direction+da)),
+        (x0+numpy.cos(-direction), y0+numpy.sin(-direction)),
+        (x0+shaft_len*numpy.cos(-direction), y0+shaft_len*numpy.sin(-direction)),
+        (x0+numpy.cos(-direction), y0+numpy.sin(-direction)),
+        (x0+numpy.cos(-direction-da), y0+numpy.sin(-direction-da)),
     ]
 
     kw.pop('marker', None)  # Ignore this

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -5,7 +5,7 @@ from matplotlib import pyplot
 
 import inspect
 from .omas_utils import *
-from omas_physics import cocos_transform
+from .omas_physics import cocos_transform
 
 __all__ = []
 

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -779,7 +779,8 @@ def gas_injection_overlay(
 @add_to__ODS__
 def pf_active_overlay(ods, ax=None, **kw):
     """
-    Plots overlays of interferometer chords.
+    Plots overlays of active PF coils.
+    INCOMPLETE: only the oblique geometry definition is treated so far. More should be added later.
 
     :param ods: OMAS ODS instance
 
@@ -819,7 +820,7 @@ def pf_active_overlay(ods, ax=None, **kw):
             fdat = [oblique['r'], oblique['z'], oblique['length'], oblique['thickness'],
                     oblique['alpha'], oblique['beta']]
 
-            ct = cocos_transform(11, ods.cocos)['BP']
+            ct = cocos_transform(ods.cocos, 11)['BP']
 
             xarr = [
                 fdat[0] - fdat[2] / 2. - fdat[3] / 2. * numpy.tan(ct*(numpy.pi/2. + fdat[5])),

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -5,6 +5,7 @@ from matplotlib import pyplot
 
 import inspect
 from .omas_utils import *
+from omas_physics import cocos_transform
 
 __all__ = []
 
@@ -293,7 +294,7 @@ def gas_arrow(ods, r, z, direction=None, snap_to=numpy.pi/4.0, ax=None, color=No
         Z position of gas injector (m)
 
     :param direction: float
-        Direction of injection (radians, COCOS 1/11)
+        Direction of injection (radians, COCOS should match ods.cocos). None = try to guess.
 
     :param snap_to: float
         Snap direction angle to nearest value. Set snap to pi/4 to snap to 0, pi/4, pi/2, 3pi/4, etc. No in-between.
@@ -317,6 +318,8 @@ def gas_arrow(ods, r, z, direction=None, snap_to=numpy.pi/4.0, ax=None, color=No
 
     if direction is None:
         direction = pick_direction()
+    else:
+        direction = cocos_transform(ods.cocos, 11)['BP'] * direction
 
     if ax is None:
         ax = pyplot.gca()
@@ -816,17 +819,19 @@ def pf_active_overlay(ods, ax=None, **kw):
             fdat = [oblique['r'], oblique['z'], oblique['length'], oblique['thickness'],
                     oblique['alpha'], oblique['beta']]
 
+            ct = cocos_transform(11, ods.cocos)['BP']
+
             xarr = [
-                fdat[0] - fdat[2] / 2. - fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5]),
-                fdat[0] - fdat[2] / 2. + fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5]),
-                fdat[0] + fdat[2] / 2. + fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5]),
-                fdat[0] + fdat[2] / 2. - fdat[3] / 2. * numpy.tan(numpy.pi/2. - fdat[5]),
+                fdat[0] - fdat[2] / 2. - fdat[3] / 2. * numpy.tan(ct*(numpy.pi/2. + fdat[5])),
+                fdat[0] - fdat[2] / 2. + fdat[3] / 2. * numpy.tan(ct*(numpy.pi/2. + fdat[5])),
+                fdat[0] + fdat[2] / 2. + fdat[3] / 2. * numpy.tan(ct*(numpy.pi/2. + fdat[5])),
+                fdat[0] + fdat[2] / 2. - fdat[3] / 2. * numpy.tan(ct*(numpy.pi/2. + fdat[5])),
             ]
             yarr = [
-                fdat[1] - fdat[3] / 2. - fdat[2] / 2. * numpy.tan(fdat[4]),
-                fdat[1] + fdat[3] / 2. - fdat[2] / 2. * numpy.tan(fdat[4]),
-                fdat[1] + fdat[3] / 2. + fdat[2] / 2. * numpy.tan(fdat[4]),
-                fdat[1] - fdat[3] / 2. + fdat[2] / 2. * numpy.tan(fdat[4]),
+                fdat[1] - fdat[3] / 2. - fdat[2] / 2. * numpy.tan(ct*-fdat[4]),
+                fdat[1] + fdat[3] / 2. - fdat[2] / 2. * numpy.tan(ct*-fdat[4]),
+                fdat[1] + fdat[3] / 2. + fdat[2] / 2. * numpy.tan(ct*-fdat[4]),
+                fdat[1] - fdat[3] / 2. + fdat[2] / 2. * numpy.tan(ct*-fdat[4]),
             ]
             path = numpy.array([xarr, yarr]).T
             patches.append(matplotlib.patches.Polygon(path, closed=True, **kw))

--- a/tests/test_omas_plot.py
+++ b/tests/test_omas_plot.py
@@ -95,6 +95,14 @@ class TestOmasPlot(unittest.TestCase):
                 pass
         ods2.plot_overlay(debug_all_plots=True)
 
+    def test_gas_arrow(self):
+        from omas.omas_plot import gas_arrow
+        self.printv('  gas_arrow ods.cocos = {}'.format(self.ods.cocos))
+        # Explicitly test the direction keyword
+        gas_arrow(self.ods, 1.5, 0.0, direction=0, color='k')
+        gas_arrow(self.ods, 1.5, 0.0, direction=numpy.pi/2, color='gray')
+        gas_arrow(self.ods, 1.5, 0.0, direction=-numpy.pi/4.5, color='m')
+
     # Equilibrium cross section plot
     def test_eqcx(self):
         self.ods.plot_equilibrium_CX()


### PR DESCRIPTION
- Cope with the possibility that the ODS is not in COCOS 11.
- Also reversed the convention for oblique angles in PF active (both here and in OMFIT). OMFIT loads them in COCOS 11. The calculations transform them to COCOS 11 using cocos_transform, then go about their business.
- Internally double-reversed gas arrow plot utility so it will be consistent with its own direction keyword, in case that thing ever makes it into IDS so it can be used outside of this test.