### PR TITLE
More tests and improvements for omas_plot

### DIFF
--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -501,7 +501,8 @@ def equilibrium_summary(ods, time_index=0, fig=None, **kw):
 
 
 @add_to__ODS__
-def core_profiles_summary(ods, time_index=0, fig=None, combine_dens_temps=True, **kw):
+def core_profiles_summary(ods, time_index=0, fig=None, combine_dens_temps=True, show_thermal_fast_breakdown=True,
+                          show_total_density=False, **kw):
     '''
     Plot densities and temperature profiles for electrons and all ion species
     as per `ods['core_profiles']['profiles_1d'][time_index]`
@@ -513,6 +514,12 @@ def core_profiles_summary(ods, time_index=0, fig=None, combine_dens_temps=True, 
     :param fig: figure to plot in (a new figure is generated if `fig is None`)
 
     :param combine_dens_temps: combine species plot of density and temperatures
+
+    :param show_thermal_fast_breakdown: bool
+        Show thermal and fast components of density in addition to total if available
+
+    :param show_total_density: bool
+        Show total thermal+fast in addition to thermal/fast breakdown if available
 
     :param kw: arguments passed to matplotlib plot statements
 
@@ -533,8 +540,16 @@ def core_profiles_summary(ods, time_index=0, fig=None, combine_dens_temps=True, 
     for k, item in enumerate(what):
 
         # densities (thermal and fast)
-        for therm_fast in ['', '_fast']:
-            therm_fast_name = ['', ' (fast)'][therm_fast == '_fast']
+        for therm_fast in ['', '_thermal', '_fast']:
+            if (not show_thermal_fast_breakdown) and len(therm_fast):
+                continue  # Skip _thermal and _fast because the flag turned these details off
+            if (not show_total_density) and (len(therm_fast) == 0):
+                continue  # Skip total thermal+fast because the flag turned it off
+            therm_fast_name = {
+                '': ' (thermal+fast)',
+                '_thermal': ' (thermal)' if show_total_density else '',
+                '_fast': ' (fast)',
+            }[therm_fast]
             density = item + '.density' + therm_fast
             if item + '.density' + therm_fast in prof1d:
                 if combine_dens_temps:

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -434,7 +434,7 @@ def equilibrium_CX(ods, time_index=0, contour_smooth=3, levels=numpy.r_[0.1:10:0
 
 @add_to__ODS__
 def equilibrium_summary(ods, time_index=0, fig=None, **kw):
-    '''
+    """
     Plot equilibrium cross-section and P, q, P', FF' profiles
     as per `ods['equilibrium']['time_slice'][time_index]`
 
@@ -447,7 +447,7 @@ def equilibrium_summary(ods, time_index=0, fig=None, **kw):
     :param kw: arguments passed to matplotlib plot statements
 
     :return: figure handler
-    '''
+    """
     if fig is None:
         fig = pyplot.figure()
 
@@ -503,7 +503,7 @@ def equilibrium_summary(ods, time_index=0, fig=None, **kw):
 @add_to__ODS__
 def core_profiles_summary(ods, time_index=0, fig=None, combine_dens_temps=True, show_thermal_fast_breakdown=True,
                           show_total_density=False, **kw):
-    '''
+    """
     Plot densities and temperature profiles for electrons and all ion species
     as per `ods['core_profiles']['profiles_1d'][time_index]`
 
@@ -524,7 +524,7 @@ def core_profiles_summary(ods, time_index=0, fig=None, combine_dens_temps=True, 
     :param kw: arguments passed to matplotlib plot statements
 
     :return: figure handler
-    '''
+    """
     if fig is None:
         fig = pyplot.figure()
 
@@ -588,7 +588,7 @@ def core_profiles_summary(ods, time_index=0, fig=None, combine_dens_temps=True, 
 
 @add_to__ODS__
 def core_profiles_pressures(ods, time_index=0, ax=None, **kw):
-    '''
+    """
     Plot pressures in `ods['core_profiles']['profiles_1d'][time_index]`
 
     :param ods: input ods
@@ -600,7 +600,7 @@ def core_profiles_pressures(ods, time_index=0, ax=None, **kw):
     :param kw: arguments passed to matplotlib plot statements
 
     :return: axes handler
-    '''
+    """
     if ax is None:
         ax = pyplot.gca()
 

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -609,9 +609,24 @@ def core_profiles_pressures(ods, time_index=0, ax=None, **kw):
 
     for item in prof1d.flat().keys():
         if 'pressure' in item:
-            uband(x, prof1d[item], ax=ax, label=item)
+            if 'ion' in item:
+                try:
+                    i = int(item.split("ion.")[-1].split('.')[0])
+                    label = prof1d['ion'][i]['label']
+                except ValueError:
+                    label = item
+            elif 'electrons' in item:
+                label = 'e$^-$'
+            else:
+                label = item
+            if item != label:
+                label += ' (thermal)' if 'thermal' in item else ''
+                label += ' (fast)' if 'fast' in item else ''
+            uband(x, prof1d[item], ax=ax, label=label)
 
     ax.set_xlim([0, 1])
+    ax.set_ylabel('Pressure (Pa)')
+    ax.set_xlabel('$\\rho_N$')
     ax.legend(loc=0).draggable(True)
     return ax
 

--- a/omas/omas_sample.py
+++ b/omas/omas_sample.py
@@ -124,7 +124,7 @@ def misc(ods):
 
 
 @add_to_ODS
-def equilibrium(ods, time_index=0, include_profiles=False, include_phi=False):
+def equilibrium(ods, time_index=0, include_profiles=False, include_phi=False, include_wall=True):
     """
     Expands an ODS by adding a (heavily down-sampled) psi map to it with low precision. This function can overwrite
     existing data if you're not careful. The original is modified, so deepcopy first if you want different ODSs.
@@ -139,6 +139,9 @@ def equilibrium(ods, time_index=0, include_profiles=False, include_phi=False):
 
     :param include_phi: bool
         Include 1D and 2D profiles of phi (toroidal flux, for calculating rho)
+
+    :param include_wall: bool
+        Include the first wall
 
     :return: ODS instance with equilibrium data added
         Since the original is modified, it is not necessary to catch the return, but it may be convenient to do so in
@@ -209,8 +212,9 @@ def equilibrium(ods, time_index=0, include_profiles=False, include_phi=False):
             [-6.16, -5.8, -5.57, -5.14, -5.11, -5.38, -6.24, -8.08, -10.29, -14.48, -16.14],
             [-5.85, -5.73, -5.81, -5.8, -5.95, -6.2, -7., -8.46, -10.1, -12.77, -13.89]])
 
-    ods['wall.description_2d.0.limiter.unit.0.outline.r'] = wall_r_small
-    ods['wall.description_2d.0.limiter.unit.0.outline.z'] = wall_z_small
+    if include_wall:
+        ods['wall.description_2d.0.limiter.unit.0.outline.r'] = wall_r_small
+        ods['wall.description_2d.0.limiter.unit.0.outline.z'] = wall_z_small
 
     return ods
 

--- a/omas/omas_sample.py
+++ b/omas/omas_sample.py
@@ -124,12 +124,21 @@ def misc(ods):
 
 
 @add_to_ODS
-def equilibrium(ods, time_index=0):
+def equilibrium(ods, time_index=0, include_profiles=False, include_phi=False):
     """
     Expands an ODS by adding a (heavily down-sampled) psi map to it with low precision. This function can overwrite
     existing data if you're not careful. The original is modified, so deepcopy first if you want different ODSs.
 
     :param ods: ODS instance
+
+    :param time_index: int
+        Under which time index should fake equilibrium data be loaded?
+
+    :param include_profiles: bool
+        Include 1D profiles of pressure, q, p', FF'
+
+    :param include_phi: bool
+        Include 1D and 2D profiles of phi (toroidal flux, for calculating rho)
 
     :return: ODS instance with equilibrium data added
     """
@@ -159,7 +168,7 @@ def equilibrium(ods, time_index=0):
     wall_z_small = numpy.array([-0., 1.21, 1.12, 1.17, 1.19, 1.17, 1.29, 1.31, 1.32, 1.16, 1.18, 1.23, 1.1, 1.14, 0.81,
                                 0.09, -0.59, -1.27, -1.3, -0.38])
 
-    ods['equilibrium.time_slice'][time_index]['profiles_1d.psi'] = numpy.linspace(0,1,11)
+    ods['equilibrium.time_slice'][time_index]['profiles_1d.psi'] = numpy.linspace(0, 1, 11)
     ods['equilibrium.time_slice'][time_index]['profiles_2d.0.psi'] = psi_small
     ods['equilibrium.time_slice'][time_index]['profiles_2d.0.grid.dim1'] = grid1_small
     ods['equilibrium.time_slice'][time_index]['profiles_2d.0.grid.dim2'] = grid2_small
@@ -170,8 +179,37 @@ def equilibrium(ods, time_index=0):
     ods['equilibrium.time_slice'][time_index]['global_quantities.magnetic_axis.r'] = 1.77
     ods['equilibrium.time_slice'][time_index]['global_quantities.magnetic_axis.z'] = 0.05
 
+    if include_profiles:
+        ods['equilibrium.time_slice'][time_index]['profiles_1d.pressure'] = numpy.array([
+            102419.25, 86877.77, 72251.59, 59232.62, 47208.7, 36590.41, 27260.38, 18938.6, 12319.77, 6356.33, 2239.37])
+        ods['equilibrium.time_slice'][time_index]['profiles_1d.q'] = numpy.array([
+            -0.92, -1.08, -1.08, -1.26, -1.32, -1.42, -1.75, -1.68, -2.43, -2.28, -3.75])
+        ods['equilibrium.time_slice'][time_index]['profiles_1d.dpressure_dpsi'] = numpy.array([
+            -89728.68, -82951.89, -75891.34, -69131.76, -62145.72, -55283.47, -48456.6, -41369.76, -34742.06, -27488.37,
+            -20863.08])
+        ods['equilibrium.time_slice'][time_index]['profiles_1d.f_df_dpsi'] = numpy.array([
+            -0.31, -0.27, -0.23, -0.19, -0.15, -0.12, -0.09, -0.07, -0.05, -0.03, -0.02])
+
+    if include_phi:
+        ods['equilibrium.time_slice'][time_index]['profiles_1d.phi'] = numpy.array([
+            1.11e-05, -1.77e-01, -3.77e-01, -5.85e-01, -8.19e-01, -1.07e+00, -1.36e+00, -1.68e+00, -2.05e+00, -2.48e+00,
+            -3.03e+00])
+        ods['equilibrium.time_slice'][time_index]['profiles_2d.0.psi'] = numpy.array([
+            [-4.09, -2.65, -1.87, -1.86, -2.54, -2.63, -4.17, -7.24, -9.35, -11.34, -12.54],
+            [-4.48, -3.37, -3.14, -2.92, -3.3, -4.16, -5.91, -8.89, -12.19, -17.83, -20.1],
+            [-5.97, -5., -4.21, -3.34, -3.42, -4.04, -5.57, -8.7, -12.09, -18.82, -21.72],
+            [-7.06, -5.69, -4., -2.73, -2.19, -2.14, -2.78, -4.74, -7.78, -11.38, -14.28],
+            [-7.25, -5.49, -3.21, -1.79, -1.12, -0.7, -0.76, -1.32, -3.1, -6.86, -11.06],
+            [-7.24, -5.16, -2.74, -1.31, -0.6, -0.06, -0.03, -0.51, -1.16, -4.18, -8.06],
+            [-7.06, -5.12, -2.79, -1.37, -0.65, -0.09, -0.03, -0.45, -1.21, -4.16, -8.42],
+            [-7.17, -5.71, -3.67, -2.17, -1.44, -1.03, -1.07, -1.65, -3.41, -7.17, -11.55],
+            [-7.23, -6.16, -4.88, -3.68, -3., -2.83, -3.31, -4.91, -7.35, -10.69, -13.04],
+            [-6.16, -5.8, -5.57, -5.14, -5.11, -5.38, -6.24, -8.08, -10.29, -14.48, -16.14],
+            [-5.85, -5.73, -5.81, -5.8, -5.95, -6.2, -7., -8.46, -10.1, -12.77, -13.89]])
+
     ods['wall.description_2d.0.limiter.unit.0.outline.r'] = wall_r_small
     ods['wall.description_2d.0.limiter.unit.0.outline.z'] = wall_z_small
+
     return ods
 
 

--- a/omas/omas_sample.py
+++ b/omas/omas_sample.py
@@ -220,7 +220,7 @@ def equilibrium(ods, time_index=0, include_profiles=False, include_phi=False, in
 
 
 @add_to_ODS
-def profiles(ods, time_index=0, nx=11):
+def profiles(ods, time_index=0, nx=11, add_junk_ion=False):
     """
     Add made up sample profiles to an ODS. Although made up, the profiles satisfy quasi-neutrality and should very
     roughly resemble something similar to a real plasma a little bit.
@@ -231,6 +231,9 @@ def profiles(ods, time_index=0, nx=11):
 
     :param nx: int
         Number of points in test profiles
+
+    :param add_junk_ion: bool
+        Flag for adding a junk ion for testing how well functions tolerate problems. This will be missing labels, etc.
 
     :return: ODS instance with profiles added.
         Since the original is modified, it is not necessary to catch the return, but it may be convenient to do so in
@@ -268,6 +271,15 @@ def profiles(ods, time_index=0, nx=11):
     prof1d['ion.1.temperature'] = prof1d['ion.0.temperature']*0.98
     prof1d['ion.1.pressure'] = prof1d['ion.1.temperature'] * prof1d['ion.1.density'] * ee
     prof1d['ion.1.pressure_thermal'] = prof1d['ion.1.temperature'] * prof1d['ion.1.density_thermal'] * ee
+
+    if add_junk_ion:
+        junki = prof1d['ion.2']
+        junki['density'] = x*0
+        junki['temperature'] = x*0
+        junki['pressure'] = x*0
+
+        junkn = prof1d['neutral.0']
+        junkn['density'] = x*0
 
     return ods
 

--- a/omas/omas_sample.py
+++ b/omas/omas_sample.py
@@ -196,7 +196,7 @@ def equilibrium(ods, time_index=0, include_profiles=False, include_phi=False):
         ods['equilibrium.time_slice'][time_index]['profiles_1d.phi'] = numpy.array([
             1.11e-05, -1.77e-01, -3.77e-01, -5.85e-01, -8.19e-01, -1.07e+00, -1.36e+00, -1.68e+00, -2.05e+00, -2.48e+00,
             -3.03e+00])
-        ods['equilibrium.time_slice'][time_index]['profiles_2d.0.psi'] = numpy.array([
+        ods['equilibrium.time_slice'][time_index]['profiles_2d.0.phi'] = numpy.array([
             [-4.09, -2.65, -1.87, -1.86, -2.54, -2.63, -4.17, -7.24, -9.35, -11.34, -12.54],
             [-4.48, -3.37, -3.14, -2.92, -3.3, -4.16, -5.91, -8.89, -12.19, -17.83, -20.1],
             [-5.97, -5., -4.21, -3.34, -3.42, -4.04, -5.57, -8.7, -12.09, -18.82, -21.72],

--- a/omas/omas_sample.py
+++ b/omas/omas_sample.py
@@ -237,11 +237,16 @@ def profiles(ods, time_index=0, nx=11):
         some contexts. If you do not want the original to be modified, deepcopy it first.
     """
 
+    from scipy import constants
+    ee = constants.e
+
     prof1d = ods['core_profiles.profiles_1d'][time_index]
     x = prof1d['grid.rho_tor_norm'] = numpy.linspace(0, 1, nx)
     prof1d['electrons.density'] = 1e19 * (6.5 - 1.9*x - 4.5*x**7)  # m^-3
     prof1d['electrons.density_thermal'] = prof1d['electrons.density']
     prof1d['electrons.temperature'] = 1000 * (4 - 3*x - 0.9*x**9)  # eV
+    prof1d['electrons.pressure'] = prof1d['electrons.density'] * prof1d['electrons.temperature'] * ee
+    prof1d['electrons.pressure_thermal'] = prof1d['electrons.density_thermal'] * prof1d['electrons.temperature'] * ee
 
     prof1d['ion.0.label'] = 'D+'
     prof1d['ion.0.element.0.z_n'] = 1.0
@@ -251,6 +256,8 @@ def profiles(ods, time_index=0, nx=11):
     prof1d['ion.0.density_fast'] = prof1d['ion.0.density'].max() * 0.32 * numpy.exp(-(x**2)/0.3**2/2.)
     prof1d['ion.0.density_thermal'] = prof1d['ion.0.density'] - prof1d['ion.0.density_fast']
     prof1d['ion.0.temperature'] = prof1d['electrons.temperature'] * 1.1
+    prof1d['ion.0.pressure'] = prof1d['ion.0.temperature'] * prof1d['ion.0.density'] * ee
+    prof1d['ion.0.pressure_thermal'] = prof1d['ion.0.temperature'] * prof1d['ion.0.density_thermal'] * ee
 
     prof1d['ion.1.label'] = 'C+6'
     prof1d['ion.1.element.0.z_n'] = 6.0
@@ -259,6 +266,8 @@ def profiles(ods, time_index=0, nx=11):
     prof1d['ion.1.density'] = (prof1d['electrons.density'] - prof1d['ion.0.density']) / prof1d['ion.1.element.0.z_n']
     prof1d['ion.1.density_thermal'] = prof1d['ion.1.density']
     prof1d['ion.1.temperature'] = prof1d['ion.0.temperature']*0.98
+    prof1d['ion.1.pressure'] = prof1d['ion.1.temperature'] * prof1d['ion.1.density'] * ee
+    prof1d['ion.1.pressure_thermal'] = prof1d['ion.1.temperature'] * prof1d['ion.1.density_thermal'] * ee
 
     return ods
 

--- a/omas/omas_sample.py
+++ b/omas/omas_sample.py
@@ -279,7 +279,7 @@ def profiles(ods, time_index=0, nx=11, add_junk_ion=False):
         junki['pressure'] = x*0
 
         junkn = prof1d['neutral.0']
-        junkn['density'] = x*0
+        junkn['pressure'] = x*0
 
     return ods
 

--- a/tests/test_omas_plot.py
+++ b/tests/test_omas_plot.py
@@ -113,6 +113,19 @@ class TestOmasPlot(unittest.TestCase):
         ods2.plot_equilibrium_summary(fig=plt.gcf())
         ods3.plot_equilibrium_summary(fig=plt.figure('TestOmasPlot.test_eq_summary with rho'))
 
+    def test_core_profiles(self):
+        ods2 = copy.copy(self.ods)
+        ods2.sample_profiles()
+        ods2.plot_core_profiles_summary(fig=plt.gcf())
+        ods2.plot_core_profiles_summary(
+            fig=plt.figure('TestOmasPlot.test_core_profiles totals only'), show_thermal_fast_breakdown=False,
+            show_total_density=True)
+        ods2.plot_core_profiles_summary(
+            fig=plt.figure('TestOmasPlot.test_core_profiles total and breakdown'), show_thermal_fast_breakdown=True,
+            show_total_density=True)
+        ods2.plot_core_profiles_summary(
+            fig=plt.figure('TestOmasPlot.test_core_profiles no combine temp/dens'), combine_dens_temps=False)
+
     # PF active overlay
     def test_pf_active_overlay(self):
         # Basic test

--- a/tests/test_omas_plot.py
+++ b/tests/test_omas_plot.py
@@ -119,7 +119,7 @@ class TestOmasPlot(unittest.TestCase):
         ods3.plot_equilibrium_summary(fig=plt.figure('TestOmasPlot.test_eq_summary with rho'))
 
     def test_core_profiles(self):
-        ods2 = copy.copy(self.ods)
+        ods2 = copy.deepcopy(self.ods)
         ods2.sample_profiles()
         ods2.plot_core_profiles_summary(fig=plt.gcf())
         ods2.plot_core_profiles_summary(
@@ -132,9 +132,12 @@ class TestOmasPlot(unittest.TestCase):
             fig=plt.figure('TestOmasPlot.test_core_profiles no combine temp/dens'), combine_dens_temps=False)
 
     def test_core_pressure(self):
-        ods2 = copy.copy(self.ods)
+        ods2 = copy.deepcopy(self.ods)
         ods2.sample_profiles()
         ods2.plot_core_profiles_pressures()
+        ods3 = copy.deepcopy(self.ods)
+        ods3.sample_profiles(add_junk_ion=True)
+        ods3.plot_core_profiles_pressures()
 
     # PF active overlay
     def test_pf_active_overlay(self):

--- a/tests/test_omas_plot.py
+++ b/tests/test_omas_plot.py
@@ -103,9 +103,15 @@ class TestOmasPlot(unittest.TestCase):
         gas_arrow(self.ods, 1.5, 0.0, direction=numpy.pi/2, color='gray')
         gas_arrow(self.ods, 1.5, 0.0, direction=-numpy.pi/4.5, color='m')
 
-    # Equilibrium cross section plot
+    # Equilibrium plots
     def test_eqcx(self):
         self.ods.plot_equilibrium_CX()
+
+    def test_eq_summary(self):
+        ods2 = ODS().sample_equilibrium(include_profiles=True)
+        ods3 = ODS().sample_equilibrium(include_profiles=True, include_phi=True)
+        ods2.plot_equilibrium_summary(fig=plt.gcf())
+        ods3.plot_equilibrium_summary(fig=plt.figure('TestOmasPlot.test_eq_summary with rho'))
 
     # PF active overlay
     def test_pf_active_overlay(self):

--- a/tests/test_omas_plot.py
+++ b/tests/test_omas_plot.py
@@ -131,6 +131,11 @@ class TestOmasPlot(unittest.TestCase):
         ods2.plot_core_profiles_summary(
             fig=plt.figure('TestOmasPlot.test_core_profiles no combine temp/dens'), combine_dens_temps=False)
 
+    def test_core_pressure(self):
+        ods2 = copy.copy(self.ods)
+        ods2.sample_profiles()
+        ods2.plot_core_profiles_pressures()
+
     # PF active overlay
     def test_pf_active_overlay(self):
         # Basic test

--- a/tests/test_omas_plot.py
+++ b/tests/test_omas_plot.py
@@ -106,11 +106,16 @@ class TestOmasPlot(unittest.TestCase):
     # Equilibrium plots
     def test_eqcx(self):
         self.ods.plot_equilibrium_CX()
+        ods2 = ODS().sample_equilibrium(include_phi=True)
+        ods2.plot_equilibrium_CX()  # Should be vs. rho this time
+        ods2.sample_equilibrium(time_index=1, include_wall=False).plot_equilibrium_CX()  # Get wall from slice 0
+        plt.figure('TestOmasPlot.test_eqcx missing wall')
+        ODS().sample_equilibrium(include_wall=False).plot_equilibrium_CX()  # No wall
 
     def test_eq_summary(self):
         ods2 = ODS().sample_equilibrium(include_profiles=True)
         ods3 = ODS().sample_equilibrium(include_profiles=True, include_phi=True)
-        ods2.plot_equilibrium_summary(fig=plt.gcf())
+        ods2.plot_equilibrium_summary(fig=plt.gcf(), label='label test')
         ods3.plot_equilibrium_summary(fig=plt.figure('TestOmasPlot.test_eq_summary with rho'))
 
     def test_core_profiles(self):

--- a/tests/test_omas_plot.py
+++ b/tests/test_omas_plot.py
@@ -30,6 +30,7 @@ class TestOmasPlot(unittest.TestCase):
 
     # Flags to edit while testing
     show_plots = False  # This will get in the way of automatic testing
+    keep_plots_open = False
     verbose = False  # Spammy, but occasionally useful for debugging a weird problem
 
     # Sample data for use in tests
@@ -285,12 +286,14 @@ class TestOmasPlot(unittest.TestCase):
         test_id = self.id()
         test_name = '.'.join(test_id.split('.')[-2:])
         if test_name not in ['TestOmasPlot.test_ch_count']:
-            plt.figure(test_name)
+            self.fig = plt.figure(test_name)
         self.printv('{}...'.format(test_name))
 
     def tearDown(self):
         test_name = '.'.join(self.id().split('.')[-2:])
         self.printv('    {} done.'.format(test_name))
+        if not self.keep_plots_open:
+            plt.close()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
- Change to how thermal, fast, and total densities are handled in `omas_plot.core_profiles_summary`:
  - IMAS uses plain `density` to mean the total (thermal + fast) density.
  - The plot function seemed to interpret `density` as thermal and `density_fast` as fast.
  - Plot function updated to recognize `density`, `density_thermal` and `density_fast`
  - New flags added to separately enable total and thermal/fast breakdown.
    - This thing is not yet smart enough to automatically handle an incomplete dataset. If you ask for thermal+fast breakdown without total density, but only total density is available, the plot will be blank. Workaroud: don't load an incomplete dataset.
- Cleaned up labels in `omas_plot.core_pressures_profiles`
  - Replace item location with prettier string for labels for data in the legend 
  - Add axis labels
- unittests for 
   - omas_plot.equilibriuim_summary
   - omas_plot.core_profiles_summary
   - omas_plot.core_profiles_pressures
- Additional equilibrium sample data to support testing of additional plots

Increasing test coverage is so addictive