### PR TITLE
Switch from COCOSIN & COCOSOUT to COCOSIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	@echo 'OMAS makefile help'
 	@echo ''
-	@echo ' - make requirements : build requirements.txt
+	@echo ' - make requirements : build requirements.txt'
 	@echo ' - make docs         : generate sphyix documentation'
 	@echo ' - make json         : generate IMAS json structure files'
 	@echo ' - make itm          : generate omas_itm.py from omas_imas.py'

--- a/omas/examples/omas_cocos.py
+++ b/omas/examples/omas_cocos.py
@@ -19,36 +19,40 @@ x = numpy.linspace(.1, 1, 10)
 
 # use different COCOS storage conventions
 
-ods = ODS(cocosin=11, cocos=11, cocosout=11)
+ods = ODS(cocosio=11, cocos=11)
 ods['equilibrium.time_slice.0.profiles_1d.psi'] = x
 assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], x))
 print(ods['equilibrium.time_slice.0.profiles_1d.psi'])
 
-ods = ODS(cocosin=11, cocos=2, cocosout=11)
+ods = ODS(cocosio=11, cocos=2)
 ods['equilibrium.time_slice.0.profiles_1d.psi'] = x
 assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], x))
 print(ods['equilibrium.time_slice.0.profiles_1d.psi'])
 
-# use different COCOS in/out
-
-ods = ODS(cocosin=2, cocosout=11)
+ods = ODS(cocosio=2, cocos=11)
 ods['equilibrium.time_slice.0.profiles_1d.psi'] = x
-assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], -x * 2 * numpy.pi))
+assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], x))
 print(ods['equilibrium.time_slice.0.profiles_1d.psi'])
 
-ods = ODS(cocosin=2, cocosout=2)
+ods = ODS(cocosio=2, cocos=2)
 ods['equilibrium.time_slice.0.profiles_1d.psi'] = x
+assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], x))
+print(ods['equilibrium.time_slice.0.profiles_1d.psi'])
+
+# reassign the same value
+ods = ODS(cocosio=2)
+ods['equilibrium.time_slice.0.profiles_1d.psi'] = x
+ods['equilibrium.time_slice.0.profiles_1d.psi'] = ods['equilibrium.time_slice.0.profiles_1d.psi']
 assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], x))
 print(ods['equilibrium.time_slice.0.profiles_1d.psi'])
 
 # use cocos_environment
-
-ods = ODS(cocosin=2)
-with cocos_environment(ods, cocosin=11, cocosout=11):
-    ods['equilibrium.time_slice.0.profiles_1d.psi'] = x
-    assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], x))
+ods = ODS(cocosio=2)
+ods['equilibrium.time_slice.0.profiles_1d.psi'] = x
+with cocos_environment(ods, cocosio=11):
+    assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], -x*(2*numpy.pi)))
     print(ods['equilibrium.time_slice.0.profiles_1d.psi'])
 
 ods['equilibrium.time_slice.0.profiles_1d.psi'] = x
-assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], -x * 2 * numpy.pi))
+assert (numpy.allclose(ods['equilibrium.time_slice.0.profiles_1d.psi'], x))
 print(ods['equilibrium.time_slice.0.profiles_1d.psi'])

--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -301,7 +301,7 @@ class ODS(MutableMapping):
         location = l2u([self.location, key[0]])
 
         # handle cocos transformations coming in
-        if self.cocosio != self.cocos and separator in location and location in omas_physics.cocos_signals:
+        if self.cocosio != self.cocos and separator in location and location in omas_physics.cocos_signals and not isinstance(value, ODS):
             value = value * omas_physics.cocos_transform(self.cocosio, self.cocos)[omas_physics.cocos_signals[location]]
 
         # perform consistency check with IMAS structure
@@ -433,7 +433,7 @@ class ODS(MutableMapping):
             location = l2u([self.location, key[0]])
             value=self.omas_data[key[0]]
             # handle cocos transformations going out
-            if self.cocosio != self.cocos and location in omas_physics.cocos_signals:
+            if self.cocosio != self.cocos and separator in location and location in omas_physics.cocos_signals and not isinstance(value, ODS):
                 value = value * omas_physics.cocos_transform(self.cocos, self.cocosio)[omas_physics.cocos_signals[location]]
             return value
 

--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -32,8 +32,7 @@ class ODS(MutableMapping):
                  dynamic_path_creation=omas_rcparams['dynamic_path_creation'],
                  location='',
                  cocos=omas_rcparams['cocos'],
-                 cocosin=omas_rcparams['cocosin'],
-                 cocosout=omas_rcparams['cocosout'],
+                 cocosio=omas_rcparams['cocosio'],
                  structure=None):
         """
         :param imas_version: IMAS version to use as a constrain for the nodes names
@@ -46,9 +45,7 @@ class ODS(MutableMapping):
 
         :param cocos: internal COCOS representation (this can only be set when the object is created)
 
-        :param cocosin: COCOS representation of the data that is written to the ODS
-
-        :param cocosout: COCOS representation of the data that is read from the ODS
+        :param cocosio: COCOS representation of the data that is read/written from/to the ODS
 
         :param structure: IMAS schema to use
         """
@@ -58,8 +55,7 @@ class ODS(MutableMapping):
         self.imas_version = imas_version
         self.location = location
         self._cocos = cocos
-        self.cocosin = cocosin
-        self.cocosout = cocosout
+        self.cocosio = cocosio
         if structure is None:
             structure = {}
         self.structure = structure
@@ -221,7 +217,7 @@ class ODS(MutableMapping):
         property that tells in what COCOS format the data is stored internally of the ODS
         (NOTE: this parameter can only be set when the object is created)
 
-        :return: cocosin value
+        :return: cocos value
         """
         if not hasattr(self,'_cocos'):
             self._cocos=omas_rcparams['cocos']
@@ -232,40 +228,22 @@ class ODS(MutableMapping):
         raise(AttributeError('cocos parameter is readonly!'))
 
     @property
-    def cocosin(self):
+    def cocosio(self):
         """
-        property that tells in what COCOS format the data will be input
+        property that tells in what COCOS format the data will be input/output
 
-        :return: cocosin value
+        :return: cocosio value
         """
-        if not hasattr(self,'_cocosin'):
-            self._cocosin=omas_rcparams['cocosin']
-        return self._cocosin
+        if not hasattr(self,'_cocosio'):
+            self._cocosio=omas_rcparams['cocosio']
+        return self._cocosio
 
-    @cocosin.setter
-    def cocosin(self, value):
-        self._cocosin = value
+    @cocosio.setter
+    def cocosio(self, value):
+        self._cocosio = value
         for item in self.keys():
             if isinstance(self[item], ODS):
-                self[item].cocosin = value
-
-    @property
-    def cocosout(self):
-        """
-        property that tells in what COCOS format the data should be output
-
-        :return: cocosout value
-        """
-        if not hasattr(self,'_cocosout'):
-            self._cocosout=omas_rcparams['cocosout']
-        return self._cocosout
-
-    @cocosout.setter
-    def cocosout(self, value):
-        self._cocosout = value
-        for item in self.keys():
-            if isinstance(self[item], ODS):
-                self[item].cocosout = value
+                self[item].cocosio = value
 
     @property
     def dynamic_path_creation(self):
@@ -317,14 +295,14 @@ class ODS(MutableMapping):
             value = ODS(imas_version=self.imas_version,
                         consistency_check=self.consistency_check,
                         dynamic_path_creation=self.dynamic_path_creation,
-                        cocos=self.cocos, cocosin=self.cocosin, cocosout=self.cocosout)
+                        cocos=self.cocos, cocosio=self.cocosio)
 
         # full path where we want to place the data
         location = l2u([self.location, key[0]])
 
         # handle cocos transformations coming in
-        if self.cocosin != self.cocos and separator in location and location in omas_physics.cocos_signals:
-            value = value * omas_physics.cocos_transform(self.cocosin, self.cocos)[omas_physics.cocos_signals[location]]
+        if self.cocosio != self.cocos and separator in location and location in omas_physics.cocos_signals:
+            value = value * omas_physics.cocos_transform(self.cocosio, self.cocos)[omas_physics.cocos_signals[location]]
 
         # perform consistency check with IMAS structure
         if self.consistency_check:
@@ -438,7 +416,7 @@ class ODS(MutableMapping):
                 self.__setitem__(key[0], ODS(imas_version=self.imas_version,
                                               consistency_check=self.consistency_check,
                                               dynamic_path_creation=self.dynamic_path_creation,
-                                              cocos=self.cocos, cocosin=self.cocosin, cocosout=self.cocosout))
+                                              cocos=self.cocos, cocosio=self.cocosio))
             else:
                 location = l2u([self.location, key[0]])
                 raise(LookupError('Dynamic path creation is disabled, hence `%s` needs to be manually created'%location))
@@ -455,8 +433,8 @@ class ODS(MutableMapping):
             location = l2u([self.location, key[0]])
             value=self.omas_data[key[0]]
             # handle cocos transformations going out
-            if self.cocosout != self.cocos and location in omas_physics.cocos_signals:
-                value = value * omas_physics.cocos_transform(self.cocos, self.cocosout)[omas_physics.cocos_signals[location]]
+            if self.cocosio != self.cocos and location in omas_physics.cocos_signals:
+                value = value * omas_physics.cocos_transform(self.cocos, self.cocosio)[omas_physics.cocos_signals[location]]
             return value
 
     def __delitem__(self, key):
@@ -592,7 +570,7 @@ class ODS(MutableMapping):
 
     def copy_attrs_from(self, ods):
         '''
-        copy omas_ods_attrs ['_consistency_check','_dynamic_path_creation','imas_version','location','structure','_cocos','_cocosin','_cocosout'] attributes from input ods
+        copy omas_ods_attrs ['_consistency_check','_dynamic_path_creation','imas_version','location','structure','_cocos','_cocosio'] attributes from input ods
 
         :param ods: input ods
 
@@ -684,7 +662,7 @@ try:
 except ImportError as _excp:
     printe('OMAS plotting function are not available: ' + repr(_excp))
 
-omas_ods_attrs=['_consistency_check','_dynamic_path_creation','imas_version','location','structure','_cocos','_cocosin','_cocosout']
+omas_ods_attrs=['_consistency_check','_dynamic_path_creation','imas_version','location','structure','_cocos','_cocosio']
 omas_dictstate=dir(ODS)
 omas_dictstate.extend(['omas_data']+omas_ods_attrs)
 omas_dictstate=sorted(list(set(omas_dictstate)))

--- a/omas/omas_physics.py
+++ b/omas/omas_physics.py
@@ -240,29 +240,23 @@ def cocos_transform(cocosin_index, cocosout_index):
 
 
 @contextmanager
-def cocos_environment(ods, cocosin=None, cocosout=None):
+def cocos_environment(ods, cocosio=None):
     '''
     Provides OMAS environment within wich a certain COCOS convention is defined
 
     :param ods: ODS on which to operate
 
-    :param cocosin: input COCOS convention
-
-    :param cocosout: output COCOS convention
+    :param cocosio: input/output COCOS convention
 
     :return: ODS with COCOS convention set
     '''
-    old_cocosin = ods.cocosin
-    old_cocosout = ods.cocosout
-    if cocosin is not None:
-        ods.cocosin = cocosin
-    if cocosout is not None:
-        ods.cocosout = cocosout
+    old_cocosio = ods.cocosio
+    if cocosio is not None:
+        ods.cocosio = cocosio
     try:
         yield ods
     finally:
-        ods.cocosin = old_cocosin
-        ods.cocosout = old_cocosout
+        ods.cocosio = old_cocosio
 
 def generate_cocos_signals(structures=[], threshold=0):
     """

--- a/omas/omas_setup.py
+++ b/omas/omas_setup.py
@@ -51,8 +51,7 @@ separator = '.'
 # --------------------------------------------
 omas_rcparams = {
     'cocos':11,
-    'cocosin':11,
-    'cocosout':11,
+    'cocosio':11,
     'consistency_check': True,
     'dynamic_path_creation': True,
     'tmp_imas_dir': os.environ.get('OMAS_TMP_DIR',


### PR DESCRIPTION
This is necessary to avoid sneaky errors when doing something like:
```python
with cocos_environment(cocosin=2):
   ods['psi']=1
   ods['psi']=ods['psi']   # this line would switch sign of `ods['psi']` !!!!
```
solution is to have `cocosin==cocosout`, which we decided to unify in `cocosio`