### PR TITLE
Prevent changes to p2l_cache

### DIFF
--- a/omas/omas_utils.py
+++ b/omas/omas_utils.py
@@ -459,7 +459,7 @@ def p2l(key):
 
     key0 = ''.join(key)
     if key0 in _p2l_cache:
-        return _p2l_cache[key0]
+        return copy.deepcopy(_p2l_cache[key0])
 
     if not isinstance(key, (list, tuple)):
         key = str(key).replace('[', '.').replace(']', '').split('.')
@@ -473,7 +473,7 @@ def p2l(key):
 
     if len(_p2l_cache) > 1000:
         _p2l_cache.clear()
-    _p2l_cache[key0] = key
+    _p2l_cache[key0] = copy.deepcopy(key)
 
     return key
 


### PR DESCRIPTION
This fixes a bug in which locations with a `[:]` in it would get overwritten in the cache with a number, so that the next time that location got accessed with a different number, it would reference back to the old number.  For example, `OMFITstatefile.to_omas` would write a bunch of sources.  Every source `core_sources.source[:]` was supposed to have its own coordinate `core_sources.source[:].profiles_1d[:].grid.rho_tor_norm`, but only `core_sources.source[0].profiles_1d[0].grid.rho_tor_norm` would get created.