### PR TITLE
Bugfix! raise error on trying to create  array index in list

### DIFF
--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -622,7 +622,7 @@ class ODS(MutableMapping):
             self.omas_data.append(value)
         else:
             if not len(self.omas_data):
-                IndexError('`%s[%d]` but ods has no data' % (self.location, key[0]))
+                raise IndexError('`%s[%d]` but ods has no data' % (self.location, key[0]))
             else:
                 raise IndexError('`%s[%d]` but maximun index is %d' % (self.location, key[0], len(self.omas_data) - 1))
 

--- a/omas/tests/test_omas_core.py
+++ b/omas/tests/test_omas_core.py
@@ -136,6 +136,12 @@ class TestOmasCore(unittest.TestCase):
         # check writing setting an xarray.DataArray
         ods2['equilibrium.time_slice[2].profiles_1d.q'] = xarray.DataArray(uarray([0., 1., 2., 3.], [0, .1, .2, .3]), coords={'x': [1, 2, 3, 4]}, dims=['x'])
 
+    def test_dynamic_set_nonzero_array_index(self):
+        ods = ODS()
+        ods.consistency_check = False
+        ods.dynamic_path_creation = True
+        self.assertRaises(IndexError, ods.__setitem__, 'something.[10]', 5)
+
     def test_coordinates(self):
         ods = ods_sample()
         assert (len(ods.list_coordinates()) > 0)


### PR DESCRIPTION
Before dynamic path creation of form `something[9]` did not raise any error. Note that this behaviour is different than when the setitem has a path instead of a key, then the parts are created and auto-filled with empty ODS structures. Adding that behaviour too in a different pull request.