### PR TITLE
Added setting deeper array index

### DIFF
--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -607,24 +607,27 @@ class ODS(MutableMapping):
                     if key[0] == len(self.omas_data):
                         self.omas_data.append(value)
                     else:
-                        raise IndexError('`%s[%d]` but maximun index is %d' % (self.location, key[0], len(self.omas_data) - 1))
+                        raise IndexError('`%s[%d]` but maximum index is %d' % (self.location, key[0], len(self.omas_data) - 1))
             try:
                 self.getraw(key[0])[key[1:]] = pass_on_value
             except LookupError:
                 if dynamically_created:
                     del self[key[0]]
                 raise
+        elif isinstance(key[0], int):
+            if key[0] >= len(self.omas_data) and self.dynamic_path_creation:
+                for item in range(len(self.omas_data), key[0]):
+                    ods = ODS()
+                    ods.copy_attrs_from(self)
+                    self[item] = ods
+            if key[0] == len(self.omas_data):
+                self.omas_data.append(value)
+            else:
+                raise IndexError('`%s[%d]` but maximum index is %d' % (self.location, key[0], len(self.omas_data) - 1))
         elif isinstance(self.omas_data, dict):
             self.omas_data[key[0]] = value
         elif key[0] in self.omas_data:
             self.omas_data[key[0]] = value
-        elif key[0] == len(self.omas_data):
-            self.omas_data.append(value)
-        else:
-            if not len(self.omas_data):
-                IndexError('`%s[%d]` but ods has no data' % (self.location, key[0]))
-            else:
-                raise IndexError('`%s[%d]` but maximun index is %d' % (self.location, key[0], len(self.omas_data) - 1))
 
         # if the value is an ODS strucutre
         if isinstance(value, ODS) and value.omas_data is not None and len(value):

--- a/omas/tests/test_omas_core.py
+++ b/omas/tests/test_omas_core.py
@@ -222,6 +222,11 @@ class TestOmasCore(unittest.TestCase):
         ods['something.[7]'] = 10
         assert ods['something.[7]'] == 10
 
+    def test_set_nonexisting_array_index(self):
+        ods = ODS()
+        ods.consistency_check = False
+        ods.dynamic_path_creation = False
+        self.assertRaises(IndexError, ods.__setitem__, 'something.[10]', 5)
 
     def test_force_type(self):
         ods = ODS()

--- a/omas/tests/test_omas_core.py
+++ b/omas/tests/test_omas_core.py
@@ -214,6 +214,15 @@ class TestOmasCore(unittest.TestCase):
         ods['dataset_description'].satisfy_imas_requirements()
         assert ods['dataset_description.ids_properties.homogeneous_time'] is not None
 
+    def test_dynamic_set_existing_list_nonzero_array_index(self):
+        ods = ODS()
+        ods.consistency_check = False
+        ods.dynamic_path_creation = True
+        ods['something.[0]'] = 5
+        ods['something.[7]'] = 10
+        assert ods['something.[7]'] == 10
+
+
     def test_force_type(self):
         ods = ODS()
         ods['core_profiles.profiles_1d'][0]['ion'][0]['z_ion'] = 1


### PR DESCRIPTION
Seeing from the lines above, this would be expected behaviour. Now it triggers also when setting 'regular' deep arrays indices. If this is not expected, please add a test that tests the contrary. Fixed typo in index check error.