### PR TITLE
More robust position_control overlay and stricter warnings during tests

### DIFF
--- a/omas/__init__.py
+++ b/omas/__init__.py
@@ -1,7 +1,3 @@
-import os
-import omas.tests.warning_setup
-
 from .omas_core import *
 
 __all__ = [str(_item) for _item in locals().keys() if not (_item.startswith('__') and _item.endswith('__'))]
-

--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -1093,7 +1093,7 @@ class ODS(MutableMapping):
         return s, []
 
     def get(self, key, default=None):
-        """
+        r"""
         Check if key is present and if not return default value without creating value in omas data structure
 
         :param key: ods location

--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -1002,7 +1002,7 @@ class ODS(MutableMapping):
         return paths
 
     def pretty_paths(self, **kw):
-        """
+        r"""
         Traverse the ods and return paths that have data formatted nicely
 
         :param \**kw: extra keywords passed to the path() method
@@ -1012,7 +1012,7 @@ class ODS(MutableMapping):
         return list(map(l2i, self.paths(**kw)))
 
     def full_paths(self, **kw):
-        """
+        r"""
         Traverse the ods and return paths from root of ODS that have data
 
         :param \**kw: extra keywords passed to the path() method
@@ -1023,7 +1023,7 @@ class ODS(MutableMapping):
         return [location + path for path in self.paths(**kw)]
 
     def flat(self, **kw):
-        """
+        r"""
         Flat dictionary representation of the data
 
         :param \**kw: extra keywords passed to the path() method
@@ -1766,7 +1766,7 @@ class CodeParameters(dict):
         return list(dict.items(self))
 
     def flat(self, **kw):
-        """
+        r"""
         Flat dictionary representation of the data
 
         :param \**kw: extra keywords passed to the path() method

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -2475,9 +2475,17 @@ def position_control_overlay(
     ikw = dict(bounds_error=False, fill_value=np.NaN)
     try:
         nbp = np.shape(b['[:].r.reference.data'])[0]
+    except (IndexError, ValueError):
+        nbp = 0
+    try:
         nx = np.shape(x['[:].r.reference.data'])[0]
+    except (IndexError, ValueError):
+        nx = 0
+    try:
         ns = np.shape(s['[:].r.reference.data'])[0]
     except (IndexError, ValueError):
+        ns = 0
+    if nbp + nx + ns == 0:
         printe('Trouble accessing position_control data in ODS. Aborting plot overlay.')
         return
     r = [interp1d(b[i]['r.reference.time'], b[i]['r.reference.data'], **ikw)(t) for i in range(nbp)]

--- a/omas/tests/failed_imports.py
+++ b/omas/tests/failed_imports.py
@@ -1,7 +1,7 @@
 from omas.omas_setup import omas_rcparams
 import os
 import warnings
-from omas.tests.warning_setup import hard_warnings, set_omas_warnings
+from .tests.warning_setup import hard_warnings, set_omas_warnings
 
 try:
     import imas

--- a/omas/tests/failed_imports.py
+++ b/omas/tests/failed_imports.py
@@ -46,15 +46,13 @@ try:
 except (ImportError, ServerSelectionTimeoutError) as _excp:
     failed_MONGO = _excp
 
-if hard_warnings:
+with warnings.catch_warnings():
     warnings.simplefilter('ignore')
-try:
-    from omfit.classes.omfit_eqdsk import OMFITgeqdsk, OMFITsrc
+    try:
+        from omfit.classes.omfit_eqdsk import OMFITgeqdsk, OMFITsrc
 
-    failed_OMFIT = False
-except ImportError as _excp:
-    failed_OMFIT = _excp
-if hard_warnings:
-    set_omas_warnings()
+        failed_OMFIT = False
+    except ImportError as _excp:
+        failed_OMFIT = _excp
 
 __all__ = ['failed_IMAS', 'failed_HDC', 'failed_S3', 'failed_MONGO', 'failed_OMFIT', 'failed_UDA']

--- a/omas/tests/failed_imports.py
+++ b/omas/tests/failed_imports.py
@@ -1,7 +1,7 @@
 from omas.omas_setup import omas_rcparams
 import os
 import warnings
-from .tests.warning_setup import hard_warnings, set_omas_warnings
+from omas.tests.warning_setup import hard_warnings, set_omas_warnings
 
 try:
     import imas

--- a/omas/tests/test_omas_core.py
+++ b/omas/tests/test_omas_core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # # -*- coding: utf-8 -*-
 
 """

--- a/omas/tests/test_omas_core.py
+++ b/omas/tests/test_omas_core.py
@@ -20,6 +20,7 @@ from pprint import pprint
 # OMAS imports
 from omas import *
 from omas.omas_setup import *
+from omas.tests import warning_setup
 
 
 class TestOmasCore(unittest.TestCase):

--- a/omas/tests/test_omas_physics.py
+++ b/omas/tests/test_omas_physics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # # -*- coding: utf-8 -*-
 
 """

--- a/omas/tests/test_omas_physics.py
+++ b/omas/tests/test_omas_physics.py
@@ -23,6 +23,7 @@ import itertools
 from omas import *
 from omas.omas_utils import *
 from omas.omas_physics import *
+from omas.tests import warning_setup
 
 try:
     import pint

--- a/omas/tests/test_omas_plot.py
+++ b/omas/tests/test_omas_plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # # -*- coding: utf-8 -*-
 
 """

--- a/omas/tests/test_omas_plot.py
+++ b/omas/tests/test_omas_plot.py
@@ -28,6 +28,7 @@ from matplotlib import pyplot
 # OMAS imports
 from omas import *
 from omas.omas_utils import *
+from omas.tests import warning_setup
 
 
 class TestOmasPlot(unittest.TestCase):

--- a/omas/tests/test_omas_suite.py
+++ b/omas/tests/test_omas_suite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # # -*- coding: utf-8 -*-
 
 """

--- a/omas/tests/test_omas_suite.py
+++ b/omas/tests/test_omas_suite.py
@@ -19,6 +19,7 @@ import numpy
 # OMAS imports
 from omas import *
 from omas.tests.failed_imports import *
+from omas.tests import warning_setup
 
 
 class TestOmasSuite(unittest.TestCase):

--- a/omas/tests/test_omas_utils.py
+++ b/omas/tests/test_omas_utils.py
@@ -21,6 +21,7 @@ import copy
 # OMAS imports
 from omas import *
 from omas.omas_utils import *
+from omas.tests import warning_setup
 
 
 class TestOmasUtils(unittest.TestCase):

--- a/omas/tests/test_omas_utils.py
+++ b/omas/tests/test_omas_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # # -*- coding: utf-8 -*-
 
 """

--- a/omas/tests/warning_setup.py
+++ b/omas/tests/warning_setup.py
@@ -14,7 +14,7 @@ def set_omas_warnings():
     warnings.filterwarnings('error')
 
     # Selectively downgrade certain warnings into just warnings, but make them go off every time instead of just once.
-    warnings.filterwarnings('always', category=RuntimeWarning, message='numpy.ufunc size changed.*')
+    warnings.filterwarnings('always', category=RuntimeWarning, message='.*may indicate binary incompatibility.*')
     warnings.filterwarnings('always', category=FutureWarning, message='The Panel class is removed.*')
     warnings.filterwarnings('always', category=UserWarning, message='Attempting to set identical left==right.*')
     warnings.filterwarnings('always', category=UserWarning, message='No contour levels were found.*')

--- a/omas/tests/warning_setup.py
+++ b/omas/tests/warning_setup.py
@@ -2,7 +2,7 @@
 import warnings
 import os
 
-hard_warnings = os.environ['USER'] in ['eldond']
+hard_warnings = True
 print('Setting up OMAS warnings for user {}'.format(os.environ['USER']))
 
 

--- a/omas/tests/warning_setup.py
+++ b/omas/tests/warning_setup.py
@@ -3,7 +3,7 @@ import warnings
 import os
 
 hard_warnings = os.environ['USER'] in ['eldond']
-# hard_warnings = False
+print('Setting up OMAS warnings for user {}'.format(os.environ['USER']))
 
 
 def set_omas_warnings():


### PR DESCRIPTION
- position_control overlays:
  - Don't fail the whole overlay if just one out of boundary, strike, or X-point is missing
  - Fail if they're all missing
  - Allows plotting of boundary even if X-point and strike point are missing
- testing:
  - Was experiencing a bad interaction between OMAS and OMFIT imports. Upgraded the warnings to try to catch it.