### PR TITLE
omas_core:ODS.time fixed for highly inhomogeneous and multidimensional times

### DIFF
--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -272,11 +272,16 @@ class ODS(MutableMapping):
                 # Collapse extra dimensions, assuming time is the last one. If it isn't, this will fail.
                 while len(time0.shape) > 1:
                     time0 = numpy.take(time0, 0, axis=0)
-                for time in times.values():
-                    # Make sure all time arrays are close to the time0 we identified
-                    assert abs(time - time0).max() < 1e-7
-                extra_info['homogeneous_time'] = True
-                return time0
+
+                if all([time.size==time0.size for time in times.values()]):
+                    for time in times.values():
+                        # Make sure all time arrays are close to the time0 we identified
+                        assert abs(time - time0).max() < 1e-7
+                    extra_info['homogeneous_time'] = True
+                    return time0
+                else: # Similar to ValueError exception caught above
+                    extra_info['homogeneous_time'] = False
+                    return None
             # there are inconsistencies with different ways of specifying times in the IDS
             else:
                 raise ValueError('Inconsistent time definitions in %s' % times.keys())


### PR DESCRIPTION
This fixes https://github.com/gafusion/OMFIT-source/issues/4478

The ODS with problems is found on iris at `/cluster-scratch/smithsp/gh_4478/OMFITpickled_6ff3516709` and the problem can be demonstrated with
```python
OMFIT['ods'] = OMFITpickle('/cluster-scratch/smithsp/gh_4478//OMFITpickled_6ff3516709')
OMFIT['ods']['ic_antennas'].time()
```
which produces
```
Error in "OMFIT command box #1" at line  2
    t=OMFIT['ods']['ic_antennas'].time()
ValueError: operands could not be broadcast together with shapes (5,2000) (1000,) 
```
This pull request fixes the issue by detecting the odd shaping and returning `None`.