### PR TITLE
Plot label offsets can be iterable

### DIFF
--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -2180,7 +2180,7 @@ def magnetics_overlay(
         for i in range(sum(mask_)):
             if (labelevery > 0) and ((i % labelevery) == 0):
                 ax.text(
-                    r[mask_][i] + label_dr[mask_][i], z[mask_][i] + label_dz[mask_][i], ods[topname][i]['identifier'],
+                    r[mask_][i] + label_dr[i], z[mask_][i] + label_dz[i], ods[topname][i]['identifier'],
                     color=color_, fontsize=notesize, ha=label_ha[i], va=label_va[i],
                 )
 

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -2050,7 +2050,7 @@ def pf_active_overlay(ods, ax=None, **kw):
     mask = kw.pop('mask', numpy.ones(nc, bool))
     scalex, scaley = kw.pop('scalex', True), kw.pop('scaley', True)
     label_ha, label_va, kw = text_alignment_setup(nc, default_ha='center', default_va='center', **kw)
-    label_dr, label_dz = label_shifter(nc, **kw)
+    label_dr, label_dz = label_shifter(nc, kw)
 
     def path_rectangle(rectangle):
         """
@@ -2170,7 +2170,7 @@ def magnetics_overlay(
     mask = kw.pop('mask', numpy.ones(nbp + nfl, bool))
     notesize = kw.pop('notesize', 'xx-small')
     label_ha, label_va, kw = text_alignment_setup(nbp + nfl, **kw)
-    label_dr, label_dz = label_shifter(nbp + nfl, **kw)
+    label_dr, label_dz = label_shifter(nbp + nfl, kw)
 
     def show_mag(n, topname, posroot, label, color_, marker, mask_):
         r = numpy.array([ods[topname][i][posroot]['r'] for i in range(n)])
@@ -2228,7 +2228,7 @@ def interferometer_overlay(ods, ax=None, **kw):
     mask = kw.pop('mask', numpy.ones(nc, bool))
     notesize = kw.pop('notesize', 'medium')
     label_ha, label_va, kw = text_alignment_setup(nc, default_ha='left', default_va='top', **kw)
-    label_dr, label_dz = label_shifter(nc, **kw)
+    label_dr, label_dz = label_shifter(nc, kw)
 
     j = 0
     for i in range(nc):
@@ -2287,7 +2287,7 @@ def thomson_scattering_overlay(ods, ax=None, **kw):
     kw.setdefault('label', 'Thomson scattering')
     kw.setdefault('linestyle', ' ')
     label_ha, label_va, kw = text_alignment_setup(nc, **kw)
-    label_dr, label_dz = label_shifter(nc, **kw)
+    label_dr, label_dz = label_shifter(nc, kw)
 
     r = numpy.array([ods['thomson_scattering']['channel'][i]['position']['r'] for i in range(nc)])[mask]
     z = numpy.array([ods['thomson_scattering']['channel'][i]['position']['z'] for i in range(nc)])[mask]
@@ -2374,7 +2374,7 @@ def charge_exchange_overlay(ods, ax=None, which_pos='closest', **kw):
     }
     notesize = kw.pop('notesize', 'xx-small')
     ha, va, kw = text_alignment_setup(nc, **kw)
-    label_dr, label_dz = label_shifter(nc, **kw)
+    label_dr, label_dz = label_shifter(nc, kw)
 
     # Get channel positions; each channel has a list of positions as it can vary with time as beams switch on/off.
     r = [[numpy.NaN]] * nc
@@ -2474,7 +2474,7 @@ def bolometer_overlay(ods, ax=None, reset_fan_color=True, colors=None, **kw):
     notesize = kw.pop('notesize', 'xx-small')
     default_ha = [['right', 'left'][int(z1[i] > 0)] for i in range(ncm)]
     label_ha, label_va, kw = text_alignment_setup(ncm, default_ha=default_ha, default_va='top', **kw)
-    label_dr, label_dz = label_shifter(ncm, **kw)
+    label_dr, label_dz = label_shifter(ncm, kw)
 
     for i in range(ncm):
         if (i > 0) and (bolo_id[i][0] != bolo_id[i - 1][0]) and reset_fan_color:
@@ -2605,7 +2605,7 @@ def langmuir_probes_overlay(
     default_label = kw.pop('label', None)
     labelevery = kw.pop('labelevery', 2)
     notesize = kw.pop('notesize', 'xx-small')
-    label_dr, label_dz = label_shifter(ncem, **kw)
+    label_dr, label_dz = label_shifter(ncem, kw)
 
     # Decide which side each probe is on, for aligning annotation labels
     ha = ['center'] * ncem
@@ -2818,7 +2818,7 @@ def position_control_overlay(
     mnx = len(rx)
     mns = len(rs)
 
-    label_dr, label_dz = label_shifter(mnbp + mnx + mns, **kw)
+    label_dr, label_dz = label_shifter(mnbp + mnx + mns, kw)
 
     # Handle main plot setup and customizations
     kw.setdefault('linestyle', ' ')

--- a/omas/omas_sample.py
+++ b/omas/omas_sample.py
@@ -311,11 +311,15 @@ def pf_active(ods, nc_weird=0, nc_undefined=0):
         outline['r'] = [1.5, 1.6, 1.7, 1.5]
         outline['z'] = [0.1, 0.3, -0.1, 0]
 
-    # generate some data that is not time homogeneous
+    for i in range(nc):
+        # Give the dummy coils identifiers so the plot overlay can try to label them; otherwise the labels aren't tested
+        ods['pf_active.coil'][i]['element.0.identifier'] = f'samp{i}'
+
+    # Generate some data that are not time homogeneous
     for i in range(nc_reg):
         n = (1 + i) * 10
-        outline = ods['pf_active.coil'][i]['current.data'] = numpy.linspace(0, 1, n)
-        outline = ods['pf_active.coil'][i]['current.time'] = numpy.linspace(0, 1, n)
+        ods['pf_active.coil'][i]['current.data'] = numpy.linspace(0, 1, n)
+        ods['pf_active.coil'][i]['current.time'] = numpy.linspace(0, 1, n)
 
     return ods
 


### PR DESCRIPTION
- Give each label its own unique offset by providing a list or array of offsets
- Previously, label_r_shift and label_z_shift had to be scalars.

``` python
ods = OMFIT['efitviewer']['efitviewer_ods']  # Get an ODS with some slices in it somehow
label_r_shift = [
    0,
    0.25,
    [0.5, 0],
    [0.5, -0.25],
]
axs, axsf = square_subplots(len(label_r_shift), sharex=True, sharey=True)
for i in range(len(label_r_shift)):
    ax = axsf[i]
    ods.plot_equilibrium_CX(time_index=50, ax=ax)  # It doesn't matter which slice; just pick one
    ods.plot_gas_injection_overlay(which_gas=['GASA', 'PFX1'], label_r_shift=label_r_shift[i], ax=ax)
    ax.set_title(label_r_shift[i])
```

![image](https://user-images.githubusercontent.com/15132846/86013893-82fc4e80-b9d4-11ea-8bd9-759aa6b1d805.png)
