### PR TITLE
Handle data slicing for uncertain data

### DIFF
--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -1160,6 +1160,8 @@ class ODS(MutableMapping):
                 data = numpy.full(max_shape, 0)
             elif dtype.char in 'df':
                 data = numpy.full(max_shape, numpy.nan)
+            elif dtype.char in 'O':
+                data = numpy.full(max_shape, object())
             else:
                 raise ValueError('Not an IMAS data type %s' % dtype.char)
 

--- a/omas/tests/test_omas_core.py
+++ b/omas/tests/test_omas_core.py
@@ -168,6 +168,14 @@ class TestOmasCore(UnittestCaseOmas):
             equal_nan=True,
         )
 
+    def test_uncertain_slicing(self):
+        """Tests whether : slicing works properly with uncertain data"""
+        from uncertainties import ufloat
+        ods = ODS()
+        ods['pulse_schedule']['position_control']['x_point'][0]['z']['reference']['data'] = [ufloat(1.019, 0.02), ufloat(1.019, 0.02)]
+        result = ods['pulse_schedule.position_control.x_point.:.z.reference.data']
+        # Trips a ValueError if the dtype of the uncertain array isn't handled properly.
+
     def test_dynamic_set_nonzero_array_index(self):
         ods = ODS()
         ods.consistency_check = False


### PR DESCRIPTION
- Uncertain data look like np arrays of objects
- So if the type code is "O", initialize np.full with object() fill.
- Close #136