### PR TITLE
Installation:Do not insert private path on ITER cluster

### DIFF
--- a/omas/__init__.py
+++ b/omas/__init__.py
@@ -1,7 +1,1 @@
-import socket
-import os
-import sys
-
 from .omas_core import *
-
-__all__ = [str(_item) for _item in locals().keys() if not (_item.startswith('__') and _item.endswith('__'))]

--- a/omas/__init__.py
+++ b/omas/__init__.py
@@ -2,21 +2,6 @@ import socket
 import os
 import sys
 
-# Unfortunately ITER OMAS module is not kept up-to-date.
-# Here we detect if this OMAS version is running at ITER
-# and is the one would get by doing a `module load OMAS`
-# If so we import OMAS from where it is constantly kept
-# up to date by OMAS developers themeselves
-if (
-    os.path.exists('/home/ITER/menghio/atom/omas')
-    and '.iter.org' in socket.gethostname()
-    and '/work/imas/opt/EasyBuild/software/OMAS' in os.path.abspath(__file__)
-):
-    sys.path.insert(0, '/home/ITER/menghio/atom/omas')
-    sys.path.append('/home/ITER/menghio/atom/omas/site-packages')
-    del sys.modules['omas']
-    from omas.omas_core import *
-else:
-    from .omas_core import *
+from .omas_core import *
 
 __all__ = [str(_item) for _item in locals().keys() if not (_item.startswith('__') and _item.endswith('__'))]

--- a/omas/omas_setup.py
+++ b/omas/omas_setup.py
@@ -103,10 +103,13 @@ if os.path.exists(imas_json_dir + '/../../.git') and os.access(imas_json_dir + '
 
 class IMAS_versions(OrderedDict):
     """
-    dictionary with list of IMAS version and their sub-folder name in the imas_json_dir
+    Dictionary with list of IMAS version and their sub-folder name in the imas_json_dir
     """
 
     def __init__(self, mode='all'):
+        '''
+        :param mode: `all`, `named`, `tagged`
+        '''
         OrderedDict.__init__(self)
         if mode in ['all', 'named']:
             # first `develop/3` and other branches
@@ -118,6 +121,10 @@ class IMAS_versions(OrderedDict):
             for _item in list(map(lambda x: os.path.basename(x), sorted(glob.glob(imas_json_dir + os.sep + '*')))):
                 if _item.startswith('3'):
                     self[_item.replace('_', '.')] = _item
+        # do not include empty imas_structures directories (eg. needed to avoid issues wheen switching to old git branches)
+        for item, value in list(self.items()):
+            if not len(glob.glob(imas_json_dir + os.sep + value + os.sep + '*.json')):
+                del self[item]
 
 
 # imas versions


### PR DESCRIPTION
I believe that  @olivhoenen and @SimonPinches are requesting these changes to not subvert the advertised version of omas available on the ITER cluster via linux modules.  If these changes are merged and later omas users experience bugs with omas or lack of features for which a tagged version has been released, then the users will be redirected to @SimonPinches or any other person at ITER capable of installing the latest version of omas for the public version.  It was also proposed that there be an untagged version available at ITER, which could be kept up to date, separate from the numbered versions.  @olivhoenen also suggested that users could do a `pip install` to their home directory to get a more up to date version; although this risks users not staying up to date, and could lead to trouble and troubleshooting down the road.