### PR TITLE
ECE frequencies correctly in Hz now vs. GHz before

### DIFF
--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -535,7 +535,7 @@ def electron_cyclotron_emission_data(ods, pulse=133221, _measurements=True, fast
             ch['identifier'] = TECE + '{0:02d}'.format(ich + 1)
             ch['time'] = ece_map['TIME']
             f[:] = ece_map['FREQ'][ich]
-            ch['frequency']['data'] = f
+            ch['frequency']['data'] = f *1.e9
 
 
 @machine_mapping_function(__regression_arguments__, pulse=133221)


### PR DESCRIPTION
I incorrectly stored the ECE frequencies in GHz in the DIII-D machine mappings. The IMAS schema demands Hz and this fix makes sure that the standard is satisfied.