### PR TITLE
Fixed argument order in ece d3d mapping

### DIFF
--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -628,7 +628,7 @@ def electron_cyclotron_emission_data(ods, pulse=133221, fast_ece=False, _measure
         else:
             ch['name'] = 'ECE' + str(ich + 1)
             ch['identifier'] = TECE + '{0:02d}'.format(ich + 1)
-            ch['time'] = ece_map['TIME']
+            ch['time'] = ece_map['TIME'] * 1.0e3
             f[:] = ece_map['FREQ'][ich]
             ch['frequency']['data'] = f * 1.0e9
 

--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -572,11 +572,11 @@ def electron_cyclotron_emission_hardware(ods, pulse, fast_ece=False):
     :param fast_ece: bool
         Use data sampled at high frequency
     """
-    unwrap(electron_cyclotron_emission_data)(ods, pulse, _measurements=False, fast_ece=fast_ece)
+    unwrap(electron_cyclotron_emission_data)(ods, pulse, fast_ece=fast_ece, _measurements=False)
 
 
 @machine_mapping_function(__regression_arguments__, pulse=133221)
-def electron_cyclotron_emission_data(ods, pulse=133221, _measurements=True, fast_ece=False):
+def electron_cyclotron_emission_data(ods, pulse=133221, fast_ece=False, _measurements=True):
     """
     Loads DIII-D Electron cyclotron emission data
 

--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -628,7 +628,7 @@ def electron_cyclotron_emission_data(ods, pulse=133221, fast_ece=False, _measure
         else:
             ch['name'] = 'ECE' + str(ich + 1)
             ch['identifier'] = TECE + '{0:02d}'.format(ich + 1)
-            ch['time'] = ece_map['TIME'] * 1.0e3
+            ch['time'] = ece_map['TIME'] * 1.0e-3
             f[:] = ece_map['FREQ'][ich]
             ch['frequency']['data'] = f * 1.0e9
 


### PR DESCRIPTION
The order of the arguments for electron_cyclotron_emission_data was wrong making it unable to fetch data. This commit fixes this.