### PR TITLE
Include fusion power in neutrons

### DIFF
--- a/omas/omas_physics.py
+++ b/omas/omas_physics.py
@@ -879,6 +879,7 @@ def summary_heating_power(ods, update=True):
                 continue
             elif key == 'fusion':
                 ods_n['summary.fusion.power.value'] = numpy.array(value)
+                ods_n['summary.fusion.neutron_power_total.value'] = (14.1 / 3.5) * numpy.array(value)
                 continue
             ods_n[f'summary.heating_current_drive.{key}[0].power.value'] = numpy.array(value)
 


### PR DESCRIPTION
Strangely, `summary.fusion.power` is just the power coupled to the plasma (according the IMAS schema). This updates it, assuming it's 100% D-T fusion.

I'm not sure if we should worry about a contribution from D-D fusion. I think there's an O(1%) correction from that?