### PR TITLE
Windows compatibility via removal of `pwd` module

### DIFF
--- a/omas/omas_setup.py
+++ b/omas/omas_setup.py
@@ -27,7 +27,7 @@ OMAS v%s only runs with Python 3.6+ and you are running Python %s
         % (__version__, '.'.join(map(str, sys.version_info[:2])))
     )
 
-import pwd
+#import pwd
 import glob
 import json
 import copy

--- a/omas/omas_utils.py
+++ b/omas/omas_utils.py
@@ -865,7 +865,7 @@ def omas_global_quantities(imas_version=omas_rcparams['default_imas_version']):
 
 
 # only attempt cython if user owns this copy of omas
-if os.environ['USER'] != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:
+if os.environ['USER']: # != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:
     with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
         exec(f.read(), globals())
 else:


### PR DESCRIPTION
OMAS can be successfully built and installed on Windows machines (for example, through the Anaconda package manager) save for the dependency of OMAS on the `pwd` module, which is only available on UNIX machines. I propose to fork OMAS into a 'Windows compatible' branch where this dependency on `pwd` (which only shows up once in omas_setup.py and once in omas_utils.py) is removed