### PR TITLE
Windows compatible fix

### DIFF
--- a/omas/omas_setup.py
+++ b/omas/omas_setup.py
@@ -27,7 +27,6 @@ OMAS v%s only runs with Python 3.6+ and you are running Python %s
         % (__version__, '.'.join(map(str, sys.version_info[:2])))
     )
 
-import pwd
 import glob
 import json
 import copy
@@ -47,6 +46,9 @@ import difflib
 import weakref
 import unittest
 import itertools
+
+if os.name != 'nt': #If OS is not Windows, import pwd package
+    import pwd
 
 try:
     import tqdm

--- a/omas/omas_setup.py
+++ b/omas/omas_setup.py
@@ -47,7 +47,7 @@ import weakref
 import unittest
 import itertools
 
-if os.name != 'nt': #If OS is not Windows, import pwd package
+if os.name != 'nt':  # If OS is not Windows, import pwd package
     import pwd
 
 try:

--- a/omas/omas_utils.py
+++ b/omas/omas_utils.py
@@ -865,14 +865,11 @@ def omas_global_quantities(imas_version=omas_rcparams['default_imas_version']):
 
 
 # only attempt cython if user owns this copy of omas
-_userowned = True   #Create boolean to check for user-owned status
-if os.name != 'nt': #i.e. make sure OS is NOT Windows
-    if os.environ['USER'] != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:    #If user is NOT owner
-        with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
-            exec(f.read(), globals())
-        _userowned = False  #Set _userowned to False
-                
-if _userowned:
+# disabled for Windows: need to add check for file ownership under Windows
+if os.name != 'nt' and os.environ['USER'] != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:
+    with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
+        exec(f.read(), globals())
+else:
     try:
         import pyximport
 

--- a/omas/omas_utils.py
+++ b/omas/omas_utils.py
@@ -865,10 +865,14 @@ def omas_global_quantities(imas_version=omas_rcparams['default_imas_version']):
 
 
 # only attempt cython if user owns this copy of omas
-if os.environ['USER'] != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:
-    with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
-        exec(f.read(), globals())
-else:
+_userowned = True   #Create boolean to check for user-owned status
+if os.name != 'nt': #i.e. make sure OS is NOT Windows
+    if os.environ['USER'] != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:    #If user is NOT owner
+        with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
+            exec(f.read(), globals())
+        _userowned = False  #Set _userowned to False
+                
+if _userowned:
     try:
         import pyximport
 

--- a/omas/omas_utils.py
+++ b/omas/omas_utils.py
@@ -866,7 +866,7 @@ def omas_global_quantities(imas_version=omas_rcparams['default_imas_version']):
 
 # only attempt cython if user owns this copy of omas
 # disabled for Windows: need to add check for file ownership under Windows
-if os.name != 'nt' and os.environ['USER'] != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:
+if os.name == 'nt' or os.environ['USER'] != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:
     with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
         exec(f.read(), globals())
 else:


### PR DESCRIPTION
OMAS can be successfully built and installed on Windows machines (for example, through the Anaconda package manager) save for the dependency of OMAS on the pwd module, which is only available on UNIX machines. I introduce two small `os.name != 'nt'` checks that bypass the importing and utilization of the `pwd` package if the OS turns out to be Windows. 