### PR TITLE
Setting COCOS transformations for current data in coils_non_axisymmetric

### DIFF
--- a/omas/omas_cocos.py
+++ b/omas/omas_cocos.py
@@ -81,8 +81,8 @@ _cocos_signals['coils_non_axisymmetric.coil.:.conductor.:.elements.centres.phi']
 _cocos_signals['coils_non_axisymmetric.coil.:.conductor.:.elements.end_points.phi']='TOR'                        # 2.000000 # phi  [rad]
 _cocos_signals['coils_non_axisymmetric.coil.:.conductor.:.elements.intermediate_points.phi']='TOR'               # 2.000000 # phi  [rad]
 _cocos_signals['coils_non_axisymmetric.coil.:.conductor.:.elements.start_points.phi']='TOR'                      # 2.000000 # phi  [rad]
-_cocos_signals['coils_non_axisymmetric.coil.:.conductor.:.current.data']='?'                              #[ADD?]# 1.833333 # current  [A]
-_cocos_signals['coils_non_axisymmetric.coil.:.current.data']='?'                                          #[ADD?]# 1.750000 # current  [A]
+_cocos_signals['coils_non_axisymmetric.coil.:.conductor.:.current.data']=None                                    # 1.833333 # current  [A]
+_cocos_signals['coils_non_axisymmetric.coil.:.current.data']=None                                                # 1.750000 # current  [A]
 
 # CONTROLLERS
 


### PR DESCRIPTION
No transformation should be applied unless the minor radius direction or
relationship between positive current and positive field changes.  These
transformations are not available in COCOS so they would need to be
implemented another way instead.
