### PR TITLE
Testbase: Add test of h5 with consistency check = False

### DIFF
--- a/omas/omas_h5.py
+++ b/omas/omas_h5.py
@@ -137,7 +137,7 @@ def load_omas_h5(filename, consistency_check=True, imas_version=omas_rcparams['d
     return ods
 
 
-def through_omas_h5(ods, method=['function', 'class_method'][1]):
+def through_omas_h5(ods, method=['function', 'class_method'][1], consistency_check=True):
     """
     Test save and load OMAS HDF5
 
@@ -149,8 +149,8 @@ def through_omas_h5(ods, method=['function', 'class_method'][1]):
     ods = copy.deepcopy(ods)  # make a copy to make sure save does not alter entering ODS
     if method == 'function':
         save_omas_h5(ods, filename)
-        ods1 = load_omas_h5(filename)
+        ods1 = load_omas_h5(filename, consistency_check=consistency_check)
     else:
         ods.save(filename)
-        ods1 = ODS().load(filename)
+        ods1 = ODS(consistency_check=consistency_check).load(filename)
     return ods1

--- a/omas/tests/test_omas_suite.py
+++ b/omas/tests/test_omas_suite.py
@@ -48,11 +48,12 @@ class TestOmasSuite(UnittestCaseOmas):
 
     def test_omas_h5(self):
         ods = ODS().sample()
-        ods1 = through_omas_h5(ods)
-        diff = ods.diff(ods1)
-        if diff:
-            print('\n'.join(diff))
-            raise AssertionError('h5 through difference')
+        for consistency_check in [True, False]:
+            ods1 = through_omas_h5(ods, consistency_check=consistency_check)
+            diff = ods.diff(ods1)
+            if diff:
+                print('\n'.join(diff))
+                raise AssertionError(f'h5 through difference, consistency_check: {consistency_check}')
 
     def test_omas_ds(self):
         ods = ODS().sample(homogeneous_time=True)


### PR DESCRIPTION
In my/our enviroment, this test is failing. This may be caused by version h5py. (?) 