### PR TITLE
Bugfixes and test for identify_cocos

### DIFF
--- a/omas/omas_physics.py
+++ b/omas/omas_physics.py
@@ -2710,8 +2710,8 @@ def identify_cocos(B0, Ip, q, psi, clockwise_phi=None, a=None):
         index = numpy.argmin(numpy.abs(q))
         if index == 0:
             index += 1
-        q_estimate = numpy.abs((pi * B0 * (a - a[0]) ** 2) / (psi - psi[0]))
-        if numpy.abs(q_estimate[index] - q[index]) < numpy.abs(q_estimate[index] / (2 * pi) - q[index]):
+        q_estimate = numpy.abs((numpy.pi * B0 * (a - a[0]) ** 2) / (psi - psi[0]))
+        if numpy.abs(q_estimate[index] - q[index]) < numpy.abs(q_estimate[index] / (2 * numpy.pi) - q[index]):
             eBp = 1
         else:
             eBp = 0

--- a/omas/omas_physics.py
+++ b/omas/omas_physics.py
@@ -2702,16 +2702,17 @@ def identify_cocos(B0, Ip, q, psi, clockwise_phi=None, a=None):
         (+1, +1, -1): 5,  # +Bp, +rpz, -rtp
         (+1, -1, -1): 6,  # +Bp, -rpz, -rtp
         (-1, +1, +1): 7,  # -Bp, +rpz, +rtp
-        (-1, -1, +1): 8,
-    }  # -Bp, -rpz, +rtp
+        (-1, -1, +1): 8,  # -Bp, -rpz, +rtp
+    }
 
     # identify 2*pi term in psi definition based on q estimate
     if a is not None:
         index = numpy.argmin(numpy.abs(q))
         if index == 0:
             index += 1
-        q_estimate = numpy.abs((numpy.pi * B0 * (a - a[0]) ** 2) / (psi - psi[0]))
-        if numpy.abs(q_estimate[index] - q[index]) < numpy.abs(q_estimate[index] / (2 * numpy.pi) - q[index]):
+        q_estimate = abs((numpy.pi * B0 * (a[index] - a[0]) ** 2) / (psi[index] - psi[0]))
+        q_actual = abs(q[index])
+        if abs(q_estimate - q_actual) < abs(q_estimate / (2 * numpy.pi) - q_actual):
             eBp = 1
         else:
             eBp = 0

--- a/omas/tests/test_omas_physics.py
+++ b/omas/tests/test_omas_physics.py
@@ -230,6 +230,68 @@ class TestOmasPhysics(UnittestCaseOmas):
                     assert cocos_transform(cocos_ind + cocos_add * 10, cocos_ind + cocos_add * 10)[thing] == 1
         return
 
+    def test_identify_cocos(self):
+        tests = {}
+        # Create test cases for COCOS 1, 3, 5, 7
+        odds = {
+            1: {
+                "B0": 2.5,
+                "Ip": 1e6,
+                "psi": numpy.linspace(0, 2, 3),
+                "q": numpy.linspace(0.5, 1.5, 3),
+                "clockwise_phi": False,
+                "a": numpy.linspace(0, 2, 3),
+            },
+            3: {
+                "B0": 2.5,
+                "Ip": 1e6,
+                "psi": numpy.linspace(2, 0, 3),
+                "q": numpy.linspace(-0.5, -1.5, 3),
+                "clockwise_phi": False,
+                "a": numpy.linspace(0, 2, 3),
+            },
+            5: {
+                "B0": 2.5,
+                "Ip": 1e6,
+                "psi": numpy.linspace(0, 2, 3),
+                "q": numpy.linspace(-0.5, -1.5, 3),
+                "clockwise_phi": False,
+                "a": numpy.linspace(0, 2, 3),
+            },
+            7: {
+                "B0": 2.5,
+                "Ip": 1e6,
+                "psi": numpy.linspace(2, 0, 3),
+                "q": numpy.linspace(0.5, 1.5, 3),
+                "clockwise_phi": False,
+                "a": numpy.linspace(0, 2, 3),
+            },
+        }
+        tests.update(odds)
+        # Set clockwise_phi to True in these to get COCOS 2, 4, 6, 8
+        evens = {}
+        for cocos, kwargs in odds.items():
+            even_kwargs = kwargs.copy()
+            even_kwargs["clockwise_phi"] = True
+            evens[cocos + 1] = even_kwargs
+        tests.update(evens)
+        # Multiply by factor of 2*pi to get COCOS 11 -> 18
+        tens = {}
+        for cocos, kwargs in tests.items():
+            tens_kwargs = kwargs.copy()
+            # Note: can't use *= here, as some references are shared between tests
+            tens_kwargs["psi"] = kwargs["psi"] * (2 * numpy.pi)
+            tens_kwargs["q"] = kwargs["q"] * (2 * numpy.pi)
+            tens[cocos + 10] = tens_kwargs
+        tests.update(tens)
+        # TODO include tests for negative/antiparallel B0 and Ip
+        # Run each test
+        for idx, (expected, kwargs) in enumerate(tests.items()):
+            actual = identify_cocos(**kwargs)[0]
+            err_msg = f"Expected COCOS {expected}, but found {actual} with: \n{kwargs}"
+            with self.subTest(actual=actual, expected=expected, msg=err_msg):
+                self.assertEqual(actual, expected)
+
     def test_coordsio(self):
         data5 = numpy.linspace(0, 1, 5)
         data10 = numpy.linspace(0, 1, 10)


### PR DESCRIPTION
Hi! I'm working on [Pyrokinetics](https://github.com/pyro-kinetics/pyrokinetics), and I'd like to use your functions `identify_cocos` and `cocos_transform` to ensure any equilibrium data we read in is converted to COCOS 1. When I tried using `identify_cocos`, I found that it always raised `NameError` as `pi` wasn't defined. This PR makes the following changes:

- Uses `numpy.pi` instead of `pi`, fixing the `NameError` issue
- Added unit test that checks simple examples for COCOS 1 -> 8 and 11 -> 18 (positive $B_0$ and $I_p$ only)
- Fixed error where COCOS 15 -> 18 inputs would result in COCOS 5 -> 8 due to incorrect sign of `q_estimate` in the part of the algorithm that determines $e_{Bp}$.

Please let me know if it looks like I've made a mistake anywhere or otherwise misunderstood the function. If all looks good, would it be possible to get this in a 89.1 release?