### PR TITLE
Remove pygacode as a required dependency

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install OMAS
       run: |
-        python3 -m pip install .
+        python3 -m pip install .[machine]
 
     - name: Move to root and try importing OMAS
       run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6.15'
+        python-version: '3.6'
 
     - name: Install numpy
       run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 

--- a/.github/workflows/regression_no_munittest.yml
+++ b/.github/workflows/regression_no_munittest.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 

--- a/.github/workflows/regression_no_munittest.yml
+++ b/.github/workflows/regression_no_munittest.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install OMAS
       run: |
-        python3 -m pip install .
+        python3 -m pip install .[machine]
 
     - name: Move to root and try importing OMAS
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ Cython                   # required
 omfit_classes            # required
 pexpect                  # required
 fortranformat            # required
-pygacode                 # required
 
 # omfit_classes            # machine
 # pexpect                  # machine

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,6 @@ extras_require = {
     'build_documentation': ['Sphinx', 'sphinx-bootstrap-theme', 'sphinx-gallery', 'Pillow'],
 }
 
-# make machines a "required extra"
-install_requires += extras_require['machine']
-
 # Add .json IMAS structure files to the package
 here = os.path.abspath(os.path.split(__file__)[0]) + os.sep
 


### PR DESCRIPTION
I've been trying to use some [OMAS functions in Pyrokinetics](https://github.com/pyro-kinetics/pyrokinetics/pull/161), and although everything worked fine on my machine, it caused our automated tests to fail. It looks like the same problem that was encountered in [this issue](https://github.com/gafusion/omas/issues/213), in which the build-time `numpy.distutils` requirement of pygacode was causing the install to fail.

As pygacode isn't used directly by OMAS (as far as I can tell), here I've simply removed it as a required dependency. It's still available as part of the `'machine'` extras, though I've also updated that to also not be a required install. To fix this issue in pygacode, somebody will simply need to add a `pyproject.toml`, as described in [this comment](https://github.com/gafusion/omas/issues/213#issuecomment-1437389680).

A concern I have is that these changes make `omfit_classes` an optional install, and although OMAS is written to permit this, other users may not be using `pip install omas[machine]` in their workflows and therefore this may break their automated systems. Should `omfit_classes` be moved from `extras_require.machine` to `install_requires`? As far as I can tell, neither `pexpect` nor `fortranformat` from `extras_require.machine` are currently in use. The simplest fix would be to move `omfit_classes` to `install_requires` and remove the other dependencies.

Is all of this okay? I'm not sure how OMAS is used by the majority of users, so I'm aware that I may be missing some context regarding the inclusion of pygacode as a dependency.