### PR TITLE
Fix owner check in omas_utils.py

### DIFF
--- a/omas/omas_utils.py
+++ b/omas/omas_utils.py
@@ -864,9 +864,9 @@ def omas_global_quantities(imas_version=omas_rcparams['default_imas_version']):
     return _global_quantities[imas_version]
 
 
-# only attempt cython if user owns this copy of omas
+# only attempt cython if effective user owns this copy of omas
 # disabled for Windows: need to add check for file ownership under Windows
-if os.name == 'nt' or os.environ['USER'] != pwd.getpwuid(os.stat(__file__).st_uid).pw_name:
+if os.name == 'nt' or os.geteuid() != os.stat(__file__).st_uid:
     with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
         exec(f.read(), globals())
 else:


### PR DESCRIPTION
Closes #240 

I have replaced the file ownership check via the `USER` env variable (which is not guaranteed to be set, e.g. when running as root in docker) with a call to `os.geteuid()` to check against **effective uid** of the process.

**euid** vs. **uid**: I am not an os expert, but I am quite confident that checking against euid (instead of uid) is also the correct thing to do here, since I believe the file read/write system calls also operate with euid of the current process. But that is just an edge case, usually uid==euid.