### PR TITLE
Avoid scipy deprecation warning on RectBivariateSpline import 

### DIFF
--- a/omas/omas_physics.py
+++ b/omas/omas_physics.py
@@ -3,7 +3,7 @@
 -------
 '''
 
-from scipy.interpolate.fitpack2 import RectBivariateSpline
+from scipy.interpolate import RectBivariateSpline
 from .omas_utils import *
 from .omas_core import ODS
 


### PR DESCRIPTION
Small change to import RectBivariateSpline from scipy.interpolate instead from deprecated fitpack2 submodule. 

The `requirements.txt` doesn't really specify what the minimum version of scipy is that omas supports. But I noticed that there is already a 
```
from scipy.interpolate import RectBivariateSpline
```
further down in the same file, thus this change is fully backwards compatible and avoids the import warning when using newer scipy versions.