### PR TITLE
fix(pint>=0.20) use pint.Quantity for isintance check instead of pint.quantity._Quantity

### DIFF
--- a/omas/omas_core.py
+++ b/omas/omas_core.py
@@ -961,11 +961,11 @@ class ODS(MutableMapping):
 
                     if (
                         'units' in info
-                        and isinstance(value, pint.quantity._Quantity)
+                        and isinstance(value, pint.Quantity)
                         or (
                             isinstance(value, numpy.ndarray)
                             and value.size
-                            and isinstance(numpy.atleast_1d(value).flat[0], pint.quantity._Quantity)
+                            and isinstance(numpy.atleast_1d(value).flat[0], pint.Quantity)
                         )
                     ):
                         value = value.to(info['units']).magnitude


### PR DESCRIPTION
Fixes #263 

This should even be backwards compatible because in older pint versions
`pint.Quantity` is just pointing to `pint.quantity._Quantity`. 

I tested `make test_physics` with `pint==0.19` and `pint==0.22` and the tests passed in both cases.