### PR TITLE
The E coils and F coils do not use same unit

### DIFF
--- a/omas/machine_mappings/_efit.json
+++ b/omas/machine_mappings/_efit.json
@@ -315,20 +315,8 @@
    "TDI": "size(\\{EFIT_tree}::TOP.MEASUREMENTS.ECCURT,0) + size(\\{EFIT_tree}::TOP.MEASUREMENTS.FCCURT,0)",
    "treename": "{EFIT_tree}"
  },
- "equilibrium.time_slice.:.constraints.pf_current.:.measured": {
-  "eval2TDI": "py2tdi(stack_outer_2,'\\{EFIT_tree}::TOP.MEASUREMENTS.ECCURT','\\{EFIT_tree}::TOP.MEASUREMENTS.FCCURT')",
-  "treename": "{EFIT_tree}"
- },
- "equilibrium.time_slice.:.constraints.pf_current.:.measured_error_upper": {
-  "eval2TDI": "py2tdi(stack_outer_2,'\\{EFIT_tree}::TOP.MEASUREMENTS.SIGECC','\\{EFIT_tree}::TOP.MEASUREMENTS.SIGFCC')",
-  "treename": "{EFIT_tree}"
- },
  "equilibrium.time_slice.:.constraints.pf_current.:.weight": {
   "eval2TDI": "py2tdi(stack_outer_2,'\\{EFIT_tree}::TOP.MEASUREMENTS.FWTEC','\\{EFIT_tree}::TOP.MEASUREMENTS.FWTFC')",
-  "treename": "{EFIT_tree}"
- },
- "equilibrium.time_slice.:.constraints.pf_current.:.reconstructed": {
-  "eval2TDI": "py2tdi(stack_outer_2,'\\{EFIT_tree}::TOP.MEASUREMENTS.CECURR','\\{EFIT_tree}::TOP.MEASUREMENTS.CCBRSP')",
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.pf_current.:.chi_squared": {


### PR DESCRIPTION
The E and F coils are combined when loading from the EFIT tree. However, the F coils have the turns multiplied with the current, which one could argue is an preexisting error in MDS+. This would be at least consistently wrong but the F-coils are combined with the E-coils in `pf_current` in `constraints` which are stored correctly.
Following options:
- Merge this and remove the mapping completely
- Try to fix the mapping, but this is tricky because the information on how many windings each coil has is not MDS+. For DIII-D there is some expectation that the F-coils always have the same amount of turns for all shots, but the EFIT tree and mapping is not DIII-D specific, so it gets complicated very quickly.
- Leave it because it is consistent how the code wants its `pf_current`s. Here it is important to remember that this is the mapping for EFIT not the mapping for `pf_active`.
I leave it to @smithsp to make an executive decision and @bechtt to add his own opinion.