### PR TITLE
fix(structure): ensure add_extra_structures resets all required caches

### DIFF
--- a/omas/omas_structure.py
+++ b/omas/omas_structure.py
@@ -588,6 +588,7 @@ def add_extra_structures(extra_structures, lifecycle_status='tmp'):
     # reset structure caches
     omas_utils._structures = {}
     omas_utils._structures_dict = {}
+    omas_utils._ods_structure_cache = {}
 
     # add _structures
     for _ids in extra_structures:

--- a/omas/tests/test_omas_core.py
+++ b/omas/tests/test_omas_core.py
@@ -577,6 +577,27 @@ class TestOmasCore(UnittestCaseOmas):
         assert ods1['core_profiles.profiles_1d.0.ion.0.element[0].z_n'] == 1.5
         assert ods1['equilibrium.time_slice[0].profiles_2d[0].psi'][0, 1] == 1.5
 
+    def test_add_extra_structures(self):
+        from omas.omas_structure import add_extra_structures, imas_structure
+
+        original = imas_structure("3.39.0", "wall.description_2d.0.limiter.unit.0")
+        extension = {
+            "wall": {
+                "wall.description_2d[:].limiter.unit[:].test_field": {
+                    "data_type": "STR_0D",
+                    "documentation": "Test field Name",
+                    "full_path": "wall/description_2d(i1)/limiter/unit(i2)/test_field",
+                    "type": "static",
+                }
+            }
+        }
+        add_extra_structures(extension)
+        extended = imas_structure("3.39.0", "wall.description_2d.0.limiter.unit.0")
+
+        assert 'test_field' not in original
+        assert 'test_field' in extended
+
+
     # End of TestOmasCore class
 
 


### PR DESCRIPTION
I think there is a small bug in `add_extra_structures`

If the structure is already loaded and then extended the extension doesn't properly show up. 
See below, where `test_field` is missing from the output of the second `imas_structure` call.
<img width="640" alt="image" src="https://github.com/gafusion/omas/assets/11351671/ae1cef45-f827-429f-9f76-c57679407f64">

This means that e.g. a `ODS().load()` call will fail because the structure caches for `limiter.unit` will not contain `test_filed`.

This PR adds `omas.omas_utils._ods_structure_cache = {}` to the other resets in `add_extra_structures` to fix this behaviour.

I've also added a test for this.
