### PR TITLE
Upgrade python version to 3.8

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.8'
 
     - name: Install numpy
       run: |

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -800,7 +800,7 @@ def equilibrium_CX(
             z = scipy.ndimage.zoom(z, sf)
             value_2d = scipy.ndimage.zoom(value_2d, sf)
 
-        cs = ax.contour(r, z, value_2d, levels, **kw)
+        cs = ax.contour(r, z, value_2d, levels=levels, **kw)
 
         if label_contours or ((label_contours is None) and (contour_quantity == 'q')):
             ax.clabel(cs)


### PR DESCRIPTION
During debugging of the pipeline failure in #293, I noticed that the errors actually seem to come from the upgrade to python 3.8.

This PR currently only upgrades the python version to 3.8, which is a prerequisite for #293.

Before I spent more time on this I'd like to understand if an upgrade of the python version is an option for you. 3.6 is by now quite old and was end of life in 2021, and even 3.8 is going to be end of life this October, [see here](https://devguide.python.org/versions/)