### PR TITLE
refactor(test) remove workaround for old omfit_classes version

### DIFF
--- a/omas/tests/test_omas_examples.py
+++ b/omas/tests/test_omas_examples.py
@@ -97,12 +97,6 @@ class TestOmasExamples(UnittestCaseOmas):
 
     @unittest.skipIf(failed_OMFIT, str(failed_OMFIT))
     def test_plot_g_s_2_ip(self):
-        # on 3.7 this test raises:
-        # ValueError: Number of rows must be a positive integer, not 7.0
-        # It seems like this is caused by a bug in omfit_classes where a float
-        # instead of int is passed to plot
-        if sys.version_info.minor==7:
-            raise unittest.SkipTest("Avoid Py 3.7 omfit_classes bug.")
         from omas.examples import plot_g_s_2_ip
 
     def test_plot_saveload_scaling(self):


### PR DESCRIPTION
@kalling As promised, removing the workaround now that `omfit_classes` is updated