### PR TITLE
Improve stale bot config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,10 +10,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
+        # Do not mark issues with these labels
+        exempt-issue-labels: "bug,enhancement,WIP"
+        stale-issue-message: >
+            This issue has not seen any activity in the past 60 days.
+            It is now marked as stale and will be closed in 7 days if
+            no further activity is registered.
+        # Do not mark PRs with these labels
+        exempt-pr-labels: 'WIP,Blocked-by-other-PR'
+        stale-pr-message: >
+            This PR has not seen any activity in the past 60 days.
+            It is now marked as stale and will be closed in 7 days if
+            no further activity is registered.
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        days-before-stale: 60
+        days-before-close: 7


### PR DESCRIPTION
This PR aims to make the target of the stale bot a bit narrower by implementing the follwoing changes:

- Issues won't be closed if they have any of: https://github.com/gafusion/omas/labels/bug https://github.com/gafusion/omas/labels/enhancement https://github.com/gafusion/omas/labels/WIP
- PRs won't be closed if they have any of: https://github.com/gafusion/omas/labels/WIP https://github.com/gafusion/omas/labels/Blocked%20by%20other%20PR, 


Also updates `actions/stale` to latest version to avoid old node verision warnings.

