### PR TITLE
Support HSDS server with omas_h5.py function

### DIFF
--- a/omas/omas_h5.py
+++ b/omas/omas_h5.py
@@ -22,6 +22,8 @@ def dict2hdf5(filename, dictin, groupname='', recursive=True, lists_as_dicts=Fal
     :param lists_as_dicts: convert lists to dictionaries with integer strings
 
     :param compression: gzip compression level
+    
+    :param hsds: use HSDS (HDF5 in the remote server)
     """
     if hsds:
         import h5pyd as h5py
@@ -85,6 +87,8 @@ def save_omas_h5(ods, filename, hsds=False):
     :param ods: OMAS data set
 
     :param filename: filename or file descriptor to save to
+
+    :param hsds: use HSDS (HDF5 in the remote server)
     """
     return dict2hdf5(filename, ods, lists_as_dicts=True, hsds=hsds)
 
@@ -96,6 +100,8 @@ def convertDataset(ods, data, hsds=False):
     :param ods: input ODS to be populated
 
     :param data: HDF5 dataset of group
+
+    :param hsds: use HSDS (HDF5 in the remote server)
     """
     import h5py
 
@@ -131,6 +137,8 @@ def load_omas_h5(filename, consistency_check=True, imas_version=omas_rcparams['d
     :param imas_version: imas version to use for consistency check
 
     :param cls: class to use for loading the data
+
+    :param hsds: use HSDS (HDF5 in the remote server)
 
     :return: OMAS data set
     """

--- a/omas/omas_h5.py
+++ b/omas/omas_h5.py
@@ -103,7 +103,10 @@ def convertDataset(ods, data, hsds=False):
 
     :param hsds: use HSDS (HDF5 in the remote server)
     """
-    import h5py
+    if hsds:
+        import h5pyd as h5py
+    else:
+        import h5py
 
     keys = data.keys()
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ boto3                                              # required
 matplotlib                                         # required
 scipy                                              # required
 h5py                                               # required
+h5pyd                                              # required
 pymongo                                            # required
 dnspython                                          # required
 xmltodict                                          # required


### PR DESCRIPTION
- Updated `dict2hdf5` function to accept an `hsds` parameter to switch between `h5py` and `h5pyd`.
- Modified `save_omas_h5` to pass the `hsds` parameter to `dict2hdf5`.
- Updated `convertDataset` to pass the `hsds` parameter recursively.
- Changed `load_omas_h5` to accept an `hsds` parameter and use `h5pyd` when `hsds` is True.

These changes enable the use of HSDS (Highly Scalable Data Service) for handling HDF5 files, which can directly connect HSDS service and OMAS. (HSDS is the hdf5 based database system [https://github.com/HDFGroup/hsds](https://github.com/HDFGroup/hsds))