### PR TITLE
Add toray bhalf

### DIFF
--- a/omas/machine_mappings/d3d.json
+++ b/omas/machine_mappings/d3d.json
@@ -310,6 +310,9 @@
  "ec_launchers.beam.:.time": {
   "PYTHON": "ec_launcher_active_hardware(ods, {pulse})"
  },
+ "ec_launchers.code.parameters.toray.bhalf": {
+  "PYTHON": "ec_launcher_active_hardware(ods, {pulse})"
+ },
  "ece": {
   "PYTHON": "electron_cyclotron_emission_hardware(ods, {pulse}, {fast_ece!r})"
  },

--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -501,6 +501,7 @@ def coils_non_axisymmetric_current_data(ods, pulse):
 # ================================
 @machine_mapping_function(__regression_arguments__, pulse=170325)
 def ec_launcher_active_hardware(ods, pulse):
+    from omas.omas_core import CodeParameters
     setup = '.ECH.'
     # We need three queries in order to retrieve only the fields we need
     # First the amount of systems in use
@@ -545,7 +546,7 @@ def ec_launcher_active_hardware(ods, pulse):
         system_index = system_no - 1
         if gyrotrons[f'STAT_{system_no}'] == 0:
             continue
-        b_half.append(query["DISPERSION" + f'_{system_no}'])
+        b_half.append(systems["DISPERSION" + f'_{system_no}'])
         beam = ods['ec_launchers.beam'][system_index]
         time = np.atleast_1d(gyrotrons[f'TIME_AZIANG_{system_no}']) / 1.0e3
         if len(time) == 1:


### PR DESCRIPTION
Small addition needed for https://github.com/gafusion/OMFIT-source/pull/7203 .
It adds the `bhalf` factor that Toray uses in order to pretend to be a beam tracing code. Before it was hard-coded to `1.7 deg.` in OMFIT but now it is loaded from MDS+ and passed through properly.

We are still not loading the Gaussian optics parameters from MDS+ and Michael Ross promised me that we'll look into this in December.