### PR TITLE
test_machine_mapping_functions under each machine mappings

### DIFF
--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -1523,3 +1523,5 @@ def core_profiles_global_quantities_data(ods, pulse):
 
 
 # ================================
+if __name__ == '__main__':
+    test_machine_mapping_functions('d3d', ["core_profiles_profile_1d"], globals(), locals())

--- a/omas/machine_mappings/east.py
+++ b/omas/machine_mappings/east.py
@@ -218,4 +218,4 @@ def setup_gas_injection_hardware_description_east(ods, pulse):
 
 
 if __name__ == '__main__':
-    test_machine_mapping_functions(__all__, globals(), locals())
+    test_machine_mapping_functions("east", __all__, globals(), locals())

--- a/omas/machine_mappings/mast.py
+++ b/omas/machine_mappings/mast.py
@@ -438,4 +438,4 @@ def mse_data(ods, pulse, server=None, port=None):
 
 # =====================
 if __name__ == '__main__':
-    test_machine_mapping_functions(__all__, globals(), locals())
+    test_machine_mapping_functions("mast", __all__, globals(), locals())

--- a/omas/machine_mappings/nstxu.py
+++ b/omas/machine_mappings/nstxu.py
@@ -590,4 +590,4 @@ def charge_exchange_data(ods, pulse, edition='CT1'):
 
 # =====================
 if __name__ == '__main__':
-    test_machine_mapping_functions(__all__, globals(), locals())
+    test_machine_mapping_functions("nstxu", __all__, globals(), locals())

--- a/omas/machine_mappings/profiles_db_ccfe.py
+++ b/omas/machine_mappings/profiles_db_ccfe.py
@@ -139,4 +139,4 @@ def profile_db_to_ODS(ods, pulse, tok, db, ngrid):
 
 # =====================
 if __name__ == '__main__':
-    test_machine_mapping_functions(__all__, globals(), locals())
+    test_machine_mapping_functions("profiles_db_ccfe", __all__, globals(), locals())

--- a/omas/machine_mappings/sample.py
+++ b/omas/machine_mappings/sample.py
@@ -22,4 +22,4 @@ def sample_function(ods, pulse, user_argument='this is a test'):
 
 # =====================
 if __name__ == '__main__':
-    test_machine_mapping_functions(__all__, globals(), locals())
+    test_machine_mapping_functions("sample", __all__, globals(), locals())

--- a/omas/omas_machine.py
+++ b/omas/omas_machine.py
@@ -647,7 +647,7 @@ def test_machine_mapping_functions(machine, __all__, global_namespace, local_nam
             pprint(regression_kw)
             print('=' * len(func_name))
             ods = ODS() #consistency_check= not break_schema
-            func = eval(machine + "." + func_name, global_namespace, local_namespace)
+            func = eval(func_name, global_namespace, local_namespace)
             try:
                 try:
                     regression_kw["update_callback"] = update_mapping
@@ -776,5 +776,3 @@ def load_omas_machine(
         machine_to_omas(ods, machine, pulse, location, options, branch)
     return ods
 
-if __name__ == '__main__':
-    test_machine_mapping_functions('d3d', ["core_profiles_profile_1d"], globals(), locals())


### PR DESCRIPTION
I think having the tests at the bottom of each machine mapping file makes more sense.
While `test_machine_mapping_functions` worked for DIII-D it was broken for other devices.