### PR TITLE
make heavy dependency optional

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install -r requirements.txt
-        python3 -m pip install boto3 pymongo
+        python3 -m pip install boto3 pymongo xmltodict
 
     # numpy is a build time dependency of pygacode
     # but before pygacode 1.0 it did not specify its build dependencies correctly

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install -r requirements.txt
+        python3 -m pip install boto3 pymongo
 
     # numpy is a build time dependency of pygacode
     # but before pygacode 1.0 it did not specify its build dependencies correctly

--- a/.github/workflows/regression_no_munittest.yml
+++ b/.github/workflows/regression_no_munittest.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install OMAS
       run: |
-        python3 -m pip install .[machine]
+        python3 -m pip install .[machine, s3, mongo]
 
     - name: Move to root and try importing OMAS
       run: |

--- a/.github/workflows/regression_no_munittest.yml
+++ b/.github/workflows/regression_no_munittest.yml
@@ -26,10 +26,11 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install -r requirements.txt
+        python3 -m pip install boto3 pymongo
 
     - name: Install OMAS
       run: |
-        python3 -m pip install .[machine, s3, mongo]
+        python3 -m pip install .[machine]
 
     - name: Move to root and try importing OMAS
       run: |

--- a/.github/workflows/regression_no_munittest.yml
+++ b/.github/workflows/regression_no_munittest.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install -r requirements.txt
-        python3 -m pip install boto3 pymongo
+        python3 -m pip install boto3 pymongo xmltodict
 
     - name: Install OMAS
       run: |

--- a/imports_check.py
+++ b/imports_check.py
@@ -10,7 +10,7 @@ import warnings
 warnings.simplefilter('ignore', category=DeprecationWarning)
 warnings.simplefilter('ignore', category=FutureWarning)
 
-mapper = {'dnspython': None, 'sphinx-bootstrap-theme': None, 'sphinx-gallery': None, 'Sphinx': 'sphinx', 'Pillow': 'PIL'}
+mapper = {'sphinx-bootstrap-theme': None, 'sphinx-gallery': None, 'Sphinx': 'sphinx', 'Pillow': 'PIL'}
 
 filename = os.path.split(os.path.abspath(__file__))[0] + os.sep + 'requirements.txt'
 with open(filename, 'r') as f:

--- a/omas/tests/warning_setup.py
+++ b/omas/tests/warning_setup.py
@@ -23,7 +23,6 @@ def set_omas_warnings():
     warnings.filterwarnings('always', category=UserWarning, message='No contour levels were found.*')
     warnings.filterwarnings('always', category=matplotlib.MatplotlibDeprecationWarning)
     warnings.filterwarnings('always', category=RuntimeWarning, message='invalid value encountered.*')
-    warnings.filterwarnings('always', category=DeprecationWarning, message='please use dns.resolver.resolve.*')
     warnings.filterwarnings(
         'always', category=UserWarning, message='Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure'
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ netCDF4                                            # required
 matplotlib                                         # required
 scipy                                              # required
 h5py                                               # required
-dnspython                                          # required
 xarray                                             # required
 setuptools>=41.2                                   # required
 Cython                                             # required

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,16 +7,12 @@ numpy<2;python_version=='3.9'                      # required to use pint
 uncertainties                                      # required
 pint                                               # required
 netCDF4                                            # required
-boto3                                              # required
 matplotlib                                         # required
 scipy                                              # required
 h5py                                               # required
-pymongo                                            # required
 dnspython                                          # required
-xmltodict                                          # required
 xarray                                             # required
 setuptools>=41.2                                   # required
-tqdm                                               # required
 Cython                                             # required
 importlib_metadata <5;python_version=='3.7'        # required
 
@@ -28,10 +24,16 @@ importlib_metadata <5;python_version=='3.7'        # required
 # pyhdc                    # hdc
 
 # imas                     # imas
+# tqdm                     # imas
 
 # pyuda                    # uda
 
+# pymongo                  # mongo
+
+# boto3                    # aws
+
 # bs4                      # build_structures
+# xmltodict                # build_structures
 
 # Sphinx                   # build_documentation
 # sphinx-bootstrap-theme   # build_documentation

--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,12 @@ install_requires = [
     'uncertainties',
     'pint',
     'netCDF4',
-    'boto3',
     'matplotlib',
     'scipy',
     'h5py',
-    'pymongo',
     'dnspython',
-    'xmltodict',
     'xarray',
     'setuptools>=41.2',
-    'tqdm',
     'Cython',
     # latest xarray version that works with 3.7 doesn't work
     # with importlib_metadata >5 since they deprecated the `get()` method on Entrypoints
@@ -31,9 +27,11 @@ extras_require = {
         'pygacode',
     ],
     'hdc': ['pyhdc'],
-    'imas': ['imas'],
+    'imas': ['imas', 'tqdm'],
     'uda': ['pyuda'],
-    'build_structures': ['bs4'],
+    'mongo': ['pymongo'],
+    's3': ['boto3'],
+    'build_structures': ['bs4', 'xmltodict'],
     'build_documentation': ['Sphinx', 'sphinx-bootstrap-theme', 'sphinx-gallery', 'Pillow'],
 }
 

--- a/sphinx/source/how.rst
+++ b/sphinx/source/how.rst
@@ -145,9 +145,9 @@ The `ODS` class extends native Python dictionary and list classes with:
 +---------------+--------------------------------------------------------------------------------------+-------------------------------+----------------+-----------------------+
 | **HDF5**      | Files using binary HDF5 format (hierarchical data structure)                         | Binary file                   |       no       |          h5py         |
 +---------------+--------------------------------------------------------------------------------------+-------------------------------+----------------+-----------------------+
-| **S3**        | Cloud storage using Amazon Simple Storage Service                                    | Object Store                  |       yes      |         boto3         |
+| **S3**        | Cloud storage using Amazon Simple Storage Service                                    | Object Store                  |       yes      |   boto3 (optional)    |
 +---------------+--------------------------------------------------------------------------------------+-------------------------------+----------------+-----------------------+
-| **MongoDB**   | Document-based distributed database                                                  | MongoDB Database              |       yes      |        pymongo        |
+| **MongoDB**   | Document-based distributed database                                                  | MongoDB Database              |       yes      |  pymongo (optional)   |
 +---------------+--------------------------------------------------------------------------------------+-------------------------------+----------------+-----------------------+
 | **HDC**       | Hierarchical Dynamic Containers                                                      | Memory                        |       no       |   pyhdc (optional)    |
 +---------------+--------------------------------------------------------------------------------------+-------------------------------+----------------+-----------------------+

--- a/sphinx/source/install.rst
+++ b/sphinx/source/install.rst
@@ -5,7 +5,7 @@ Installation
 
 OMAS runs with *Python3.6+*
 
-**Pypi**: To install `OMAS with pip <https://pypi.python.org/pypi/omas/>`_ (for users):
+**PyPI**: To install `OMAS with pip <https://pypi.python.org/pypi/omas/>`_ (for users):
 
 .. code-block:: none
 
@@ -37,6 +37,50 @@ The development version of omas can also be installed with pip:
                                                                          # install packages required for extra development purposes
 
 List of `Python package requirements <_static/requirements.txt>`_.
+
+Optional dependencies
+---------------------
+
+Some dependencies are not required for the core functionality of OMAS,
+but are needed for some of the additional features.
+
+Here is a list of optional dependencies:
+
+.. Table of optional dependencies: mongo, s3, build_structures, build_documentation
+
++----------------------+----------------------+
+| **Package**          | **Description**      |
++======================+======================+
+| `mongo`              | Support for MongoDB  |
++----------------------+----------------------+
+| `s3`                 | Support for AWS S3   |
++----------------------+----------------------+
+| `build_structures`   | Support for building IMAS structures |
++----------------------+----------------------+
+| `build_documentation`| Support for building Sphinx documentation |
++----------------------+----------------------+
+
+Optional dependencies can be installed with the following command:
+
+**PyPI**:
+
+.. code-block:: none
+
+    pip install --upgrade omas[optional,optional2,...]
+
+**Conda**: All optional dependencies are installed by default. To suppress the installation of optional dependencies, use the following command:
+
+.. code-block:: none
+
+    conda install -c conda-forge omas --no-deps
+
+**GitHub**:
+
+.. code-block:: none
+
+    pip install --upgrade -e '.[optional,optional2,...]'
+
+**Note**: Skip the `--upgrade` option if you are installing the package for the first time.
 
 Installation with IMAS
 ======================


### PR DESCRIPTION
Closes #280

- [ ] Divide `S3` and `mongo` dependencies into eventual groups. 
- [ ] Remove obsolete dependencies. 
- [ ] Add installation instructions. 