### PR TITLE
Correct and verified conversion to ITER launch coordinate system

### DIFF
--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -556,8 +556,11 @@ def ec_launcher_active_hardware(ods, pulse):
         else:
             beam['time'] = np.atleast_1d(gyrotrons[f'TIME_AZIANG_{system_no}']) / 1.0e3
         ntime = len(beam['time'])
-        beam['steering_angle_tor'] = np.atleast_1d(np.deg2rad((gyrotrons[f'AZIANG_{system_no}'] - 180.0)))
-        beam['steering_angle_pol'] = np.atleast_1d(np.deg2rad((gyrotrons[f'POLANG_{system_no}'] - 90.0)))
+        phi_tor = np.atleast_1d(np.deg2rad(gyrotrons[f'AZIANG_{system_no}'] - 180.0))
+        theta_pol = np.atleast_1d(np.deg2rad(gyrotrons[f'POLANG_{system_no}'] - 90.0))
+        
+        beam['steering_angle_tor'] = -np.arcsin(np.cos(theta_pol)*np.sin(phi_tor))
+        beam['steering_angle_pol'] = np.arctan2(np.tan(theta_pol), np.cos(phi_tor))
 
         beam['identifier'] = beam['name'] = gyrotron_names[system_index]
 
@@ -1598,3 +1601,4 @@ def core_profiles_global_quantities_data(ods, pulse, PROFILES_tree="ZIPFIT01", P
 
 if __name__ == '__main__':
     test_machine_mapping_functions('d3d', ["core_profiles_profile_1d"], globals(), locals())
+


### PR DESCRIPTION
This changes the DIII-D mapping for the ECH to use the correct conversion from DIII-D to ITER angles. The calculation behind this was graciously provided by E. Poli. I have checked the initial wave vector in Torbeam against the wave vector in TORAY. 
TORAY uses:
kx = sin a cos b
ky = sin a cos b
kz = cos a
with a = t + pi/2 and b = p + pi one gets
kx = -cos(t) cos(p)
ky = -cos(t) sing(p)
kz = sin(t)
Which is the same as in Torbeam with the exception of kz which has the opposite sign. This could mean that the coordinate system in TORAY points in the opposite direction in the z direction. In practice the two codes agree perfectly now:
![image](https://github.com/user-attachments/assets/18461592-b9c9-46f7-ab5a-2e2be80bd757)
[notes_angle_convention.pdf](https://github.com/user-attachments/files/18947816/notes_angle_convention.pdf)