### PR TITLE
Update regressions to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -12,11 +12,11 @@ on:
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     # 3.12 does not yet work because numpy removed numpy.distutils that pygacode relies on
 
     steps:
@@ -54,8 +54,8 @@ jobs:
         python3 -m pip install wheel
         python3 -m pip install --no-build-isolation .[machine]
 
-    - name: Install OMAS (Py 3.6, 3.10, 3.11)
-      if: ${{matrix.python-version == '3.6' || matrix.python-version == '3.10' || matrix.python-version == '3.11' }}
+    - name: Install OMAS (Py 3.10, 3.11)
+      if: ${{matrix.python-version == '3.10' || matrix.python-version == '3.11' }}
       run: |
         python3 -m pip install .[machine]
 

--- a/.github/workflows/regression_no_munittest.yml
+++ b/.github/workflows/regression_no_munittest.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
Addresses #341.

This requires removing the Python 3.6 test since that version is no longer supported.

A larger jump to Ubuntu 24.04 is also possible (attempted in #342), but requires Python 3.7 to be retired as well. Since OMFIT is still on 3.7, this doesn't seem like a good idea yet.