### PR TITLE
Reuse MDSplus connections

### DIFF
--- a/omas/utilities/omas_mds.py
+++ b/omas/utilities/omas_mds.py
@@ -176,7 +176,7 @@ class mdsvalue(dict):
 
                     # more recent MDSplus server
                     else:
-                        conns = current_conn.getMany()
+                        conns = _mds_connection_cache[self.server].getMany()
                         for name, expr in TDI.items():
                             conns.append(name, expr)
                         res = conns.execute()
@@ -196,7 +196,7 @@ class mdsvalue(dict):
 
                 # single TDI expression
                 else:
-                    out_results = MDSplus.Data.data(current_conn.get(TDI))
+                    out_results = MDSplus.Data.data(_mds_connection_cache[self.server].get(TDI))
 
                 # return values
                 return out_results

--- a/omas/utilities/omas_mds.py
+++ b/omas/utilities/omas_mds.py
@@ -8,17 +8,7 @@ __all__ = [
     'get_pulse_id'
 ]
 
-last_tree = None
 current_conn = None
-
-def manage_open_tree(conn, treename, pulse):
-    global last_tree
-    if last_tree == (treename, pulse):
-        return
-    elif last_tree is not None:
-        conn.closeTree(*last_tree)
-    conn.openTree(treename, pulse)
-    last_tree = (treename, pulse)
 
 
 def get_pulse_id(pulse, run_id=None):
@@ -161,7 +151,7 @@ class mdsvalue(dict):
                     if current_conn is None:
                         current_conn = MDSplus.Connection(self.server)
                     try:
-                        manage_open_tree(current_conn, self.treename, self.pulse)
+                        current_conn.openTree(self.treename, self.pulse)
                         break
                     except Exception as e:
                         if fallback:


### PR DESCRIPTION
Before this PR OMAS would open a separate connection for every `(server, tree, shot)` tuple. This makes it impossible to retrieve more than `1000` unique tuples in the same session for DIII-D because Atlas enforces a 1000 connection limit.
With this change Omas cashes only a single connection and `(tree,.shot)`. So as long as you operate within the same `(tree,shot)` tuple there is no functional difference. If you move between many `(tree,shot)` tuples then this should be faster as the connection is reused. If, however, you just constantly flip-flop between two `(tree1, shot1)`, `(tree2, shot2)` tuples then it will be slower since we are constantly opening and closing trees. 
I propose we make this change even though because this can have negative side effects because it reduces footprint on Atlas and it follows best practices more than the original version.

There are a couple upgrades that can be made. My hesitation is though that the main reason for these is upgrades is to compensate for bad user patterns. In an ideal user pattern the user gets all data from one `(tree,shot)` tuple and then they move to the next. If someone has a good use-case that would require the flip-flopping between `(tree,shot)` tuples then I can see if we can handle those specifically.