### PR TITLE
Minor bug fix for the DIII-D machine mapping

### DIFF
--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -1520,7 +1520,6 @@ def core_profiles_profile_1d(ods, pulse, PROFILES_tree="OMFIT_PROFS", PROFILES_r
         query["electrons.temperature_fit.psi_norm"] = "PS_T_E"
         query["ion[1].density_fit.psi_norm"] = "PS_N_C"
         query["ion[1].temperature_fit.psi_norm"] = "PS_T_C"
-        query["ion[1].density_fit.psi_norm"] = "PS_T_C"
         query["ion[1].velocity.toroidal_fit.psi_norm"]= "PS_V_TOR_C"
         #query["j_total"] = "J_TOT"
         #query["pressure_perpendicular"] = "P_TOT"


### PR DESCRIPTION
There was an extra line that fetched the wrong psi for carbon density raw data used in the core_profile fit from the OMFIT_PROF tree. This was first uncovered because the length of psi didn't match the length of the measurement (once nans were removed).