### PR TITLE
Improvements to fetch all mapped data

### DIFF
--- a/omas/machine_mappings/_efit.json
+++ b/omas/machine_mappings/_efit.json
@@ -340,19 +340,19 @@
    "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.pressure.:.measured": {
-  "TDI": "data(\\{EFIT_tree}::TOP.MEASUREMENTS.PRESSR)",
+  "eval2TDI": "py2tdi(ensure_2d,'-\\{EFIT_tree}::TOP.MEASUREMENTS.PRESSR')",
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.pressure.:.measured_error_upper": {
-  "TDI": "data(\\{EFIT_tree}::TOP.MEASUREMENTS.SIGPRE)",
+  "eval2TDI": "py2tdi(ensure_2d,'-\\{EFIT_tree}::TOP.MEASUREMENTS.SIGPRE')",
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.pressure.:.weight": {
-  "TDI": "data(\\{EFIT_tree}::TOP.MEASUREMENTS.FWTPRE)",
+  "eval2TDI": "py2tdi(ensure_2d,'-\\{EFIT_tree}::TOP.MEASUREMENTS.FWTPRE')",
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.pressure.:.reconstructed": {
-  "TDI": "data(\\{EFIT_tree}::TOP.MEASUREMENTS.CPRESS)",
+  "eval2TDI": "py2tdi(ensure_2d,'-\\{EFIT_tree}::TOP.MEASUREMENTS.CPRESS')",
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.pressure.:.position.psi": {
@@ -360,7 +360,7 @@
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.pressure.:.chi_squared": {
-  "TDI": "data(\\{EFIT_tree}::TOP.MEASUREMENTS.SAIPRE)",
+  "eval2TDI": "py2tdi(ensure_2d,'-\\{EFIT_tree}::TOP.MEASUREMENTS.SAIPRE')",
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.j_tor.:": {
@@ -372,7 +372,7 @@
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.constraints.j_tor.:.measured": {
-  "TDI": "data(\\{EFIT_tree}::TOP.MEASUREMENTS.VZEROJ)*1.e6",
+  "eval2TDI": "py2tdi(convert_from_mega_2d,'-\\{EFIT_tree}::TOP.MEASUREMENTS.VZEROJ')",
   "treename": "{EFIT_tree}"
  },
  "equilibrium.time_slice.:.global_quantities.ip": {

--- a/omas/machine_mappings/python_tdi.py
+++ b/omas/machine_mappings/python_tdi.py
@@ -58,17 +58,32 @@ def geqdsk_psi(a, b, c):
     M = a[:, None] + np.linspace(0, 1, n).T * (b[:, None] - a[:, None])
     return M
 
-def efit_psi_to_psi(a, b, c):
-    a = a.data()
-    b = b.data()
-    c = c.data()
-    return (a - b)/(c - b)
-
 def efit_psi_to_real_psi_2d(a, b, c):
+    import numpy as np
+
     a = a.data()
+    if len(a.shape) < 2:
+        a = np.atleast_2d(a)
     b = b.data()
     c = c.data()
     return (a.T * (c - b) + b).T
+
+def convert_from_mega_2d(a):
+    import numpy as np
+
+    a = a.data()
+    if len(a.shape) < 2:
+        a = np.atleast_2d(a)
+    return a*1.e6
+
+def ensure_2d(a):
+    import numpy as np
+    
+    a = a.data()
+    if len(a.shape) < 2:
+        return np.atleast_2d(a)
+    else:
+        return a
 
 def py2tdi(func, *args):
     import inspect


### PR DESCRIPTION
These changes were required to run
`load_omas_machine('d3d', 200000)`
without any errors. Some of the fields aren't filled, but these are now skipped or zeroed without any hard failures.