### PR TITLE
This PR properly compiles cython to remove pyximport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ build/
 .DS_Store
 /site-packages/
 /tmp
-
+*.cpython*
+omas_cython.c
 omas/data-dictionary
 omas/Saxon*
 omas/imas_structures/*/*.xml

--- a/omas/omas_utils.py
+++ b/omas/omas_utils.py
@@ -868,21 +868,14 @@ def omas_global_quantities(imas_version=omas_rcparams['default_imas_version']):
     return _global_quantities[imas_version]
 
 
-# only attempt cython if effective user owns this copy of omas
-# disabled for Windows: need to add check for file ownership under Windows
-if os.name == 'nt' or os.geteuid() != os.stat(__file__).st_uid:
+# Import compiled Cython extension
+# Fall back to pure Python implementation if the compiled extension is not available
+try:
+    from .omas_cython import *
+except ImportError as _excp:
+    warnings.warn('Compiled Cython extension not available, falling back to pure Python: ' + str(_excp))
     with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
         exec(f.read(), globals())
-else:
-    try:
-        import pyximport
-
-        pyximport.install(language_level=3)
-        from .omas_cython import *
-    except Exception as _excp:
-        warnings.warn('omas cython failed: ' + str(_excp))
-        with open(os.path.split(__file__)[0] + os.sep + 'omas_cython.pyx', 'r') as f:
-            exec(f.read(), globals())
 
 
 def l2ut(path):

--- a/omas/tests/test_omas_utils.py
+++ b/omas/tests/test_omas_utils.py
@@ -117,6 +117,17 @@ class TestOmasUtils(UnittestCaseOmas):
         ods_info_list = omas_info(get_list)
         assert all(item in ods_info_list for item in get_list)
 
+    def test_cython_extension_compiled(self):
+        """Test that the Cython extension was properly compiled and is being used"""
+        import omas.omas_cython as cython_module
+        # Check that we're using the compiled extension (.so file) not the .pyx source
+        assert hasattr(cython_module, '__file__'), "Cython module should have a __file__ attribute"
+        module_file = cython_module.__file__
+        # Compiled extension should end with .so (Linux/Mac) or .pyd (Windows)
+        assert module_file.endswith('.so') or module_file.endswith('.pyd'), \
+            f"Expected compiled extension (.so/.pyd), but got: {module_file}"
+        print(f"✓ Using compiled Cython extension: {module_file}")
+
     def test_p2l(self):
         assert p2l('0') == [0]
         assert p2l('equilibrium') == ['equilibrium']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=41.2", "Cython>=0.29", "numpy>=1.16.1"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import os
 import glob
 import subprocess
+from setuptools import Extension
+from Cython.Build import cythonize
 
 install_requires = [
     'numpy>=1.16.1',
@@ -51,7 +53,7 @@ if os.path.exists(here + '.git') and not os.path.exists(here + 'requirements.txt
 
 packages = ['omas', 'omas.examples', 'omas.samples', 'omas.tests', 'omas.utilities']
 package_data = {
-    'omas': ['*.py', '*.pyx', 'version'],
+    'omas': ['*.py', 'version'],
     'omas.examples': ['*.py'],
     'omas.samples': ['*'],
     'omas.tests': ['*.py'],
@@ -109,6 +111,13 @@ print()
 
 from setuptools import setup
 
+# Build Cython extension
+ext_modules = cythonize(
+    [Extension("omas.omas_cython", ["omas/omas_cython.pyx"])],
+    language_level=3,
+    compiler_directives={'embedsignature': True}
+)
+
 setup(
     name='omas',
     version=open(here + 'omas/version', 'r').read().strip(),
@@ -124,4 +133,6 @@ setup(
     package_data=package_data,
     install_requires=install_requires,
     extras_require=extras_require,
+    ext_modules=ext_modules,
+    setup_requires=['Cython>=0.29', 'numpy>=1.16.1'],
 )


### PR DESCRIPTION
## Description

This modifies the setup.py to compile the Cython code OMAS uses

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran to verify your changes -->
There is a new tests that checks if cython was compiled properly
## Pre-Merge Checklist

- [ ] OMFIT has been tested with this OMAS version and you will create a PR on OMFIT that updates the OMAS submodule once this has been merged.
- [ ] Version number has been incremented if this is a major modification or important bug fix
  - To increment the version: Edit the version number in `omas/version` file
  - Follow semantic versioning: MAJOR.MINOR.PATCH (e.g., `0.94.2` → `0.94.3` for bug fixes, `0.94.2` → `0.95.0` for new features)
  - A GitHub release will be automatically created when this PR is merged if the version number has changed

## Additional Notes

<!-- Any additional information that reviewers should know -->
