### PR TITLE
Change 1.e30 to np.inf

### DIFF
--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -1706,11 +1706,11 @@ def magnetics_floops_data(ods, pulse, store_differential=False, nref=0):
         nt = len(ods[f'magnetics.flux_loop.{k}.flux.data'])
         if ods[f'magnetics.flux_loop.{k}.flux.validity'] == -2:
             # Set large uncertainty for invalid data
-            ods[f'magnetics.flux_loop.{k}.flux.data_error_upper'] = 1.e30 * np.ones(nt)
+            ods[f'magnetics.flux_loop.{k}.flux.data_error_upper'] = np.inf * np.ones(nt)
         elif weights[k] < 0.5:
             # Use static weight to mark sensor invalid and set large uncertainty
             ods[f'magnetics.flux_loop.{k}.flux.validity'] = -2
-            ods[f'magnetics.flux_loop.{k}.flux.data_error_upper'] = 1.e30 * np.ones(nt)
+            ods[f'magnetics.flux_loop.{k}.flux.data_error_upper'] = np.inf * np.ones(nt)
         else:
             # Convert digitizer counts (bit uncertainty) to flux
             identifier = ods1[f'magnetics.flux_loop.{k}.identifier'].upper()
@@ -1809,11 +1809,11 @@ def magnetics_probes_data(ods, pulse):
         nt = len(ods[f'magnetics.b_field_pol_probe.{k}.field.data'])
         if ods[f'magnetics.b_field_pol_probe.{k}.field.validity'] == -2:
             # Set large uncertainty for invalid data
-            ods[f'magnetics.b_field_pol_probe.{k}.field.data_error_upper'] = 1.e30 * np.ones(nt)
+            ods[f'magnetics.b_field_pol_probe.{k}.field.data_error_upper'] = np.inf * np.ones(nt)
         elif weights[k] < 0.5:
             # Use static weight to mark sensor invalid and set large uncertainty
             ods[f'magnetics.b_field_pol_probe.{k}.field.validity'] = -2
-            ods[f'magnetics.b_field_pol_probe.{k}.field.data_error_upper'] = 1.e30 * np.ones(nt)
+            ods[f'magnetics.b_field_pol_probe.{k}.field.data_error_upper'] = np.inf * np.ones(nt)
         else:
             # Convert digitizer counts (bit uncertainty) to field
             identifier = ods1[f'magnetics.b_field_pol_probe.{k}.identifier'].upper()


### PR DESCRIPTION
## Description
To be consistent, bad channels now have `np.inf` uncertainty instead `1.e30` which is arbitray.

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Pre-Merge Checklist

- [x] OMFIT has been tested with this OMAS version and you will create a PR on OMFIT that updates the OMAS submodule once this has been merged. https://github.com/gafusion/OMFIT-source/pull/7595
- [ ] Version number has been incremented if this is a major modification or important bug fix
  - To increment the version: Edit the version number in `omas/version` file
  - Follow semantic versioning: MAJOR.MINOR.PATCH (e.g., `0.94.2` → `0.94.3` for bug fixes, `0.94.2` → `0.95.0` for new features)
  - A GitHub release will be automatically created when this PR is merged if the version number has changed

## Additional Notes

<!-- Any additional information that reviewers should know -->
