### PR TITLE
RIP needs a factor 2 because currently it only counts 1 pass

### DIFF
--- a/omas/machine_mappings/d3d.py
+++ b/omas/machine_mappings/d3d.py
@@ -860,7 +860,7 @@ def rip_hardware(ods, pulse):
         z = z + (0,)
     # phi angles are compliant with odd COCOS
     phi0 = 286.6 * (-np.pi / 180.0)
-    conv0 = 6.71e15#m^-2/rad
+    conv0 = 6.71e15*2.0 #m^-2/rad *2 passes
 
     for i, ch in enumerate(channels):
         if pulse < 177052:
@@ -877,7 +877,7 @@ def rip_hardware(ods, pulse):
 
         if ch == 'T':
             phi = 283 * (-np.pi / 180.0)
-            conv = 1.436
+            conv = 1.436*2.0
         else: 
             phi = phi0
             conv = conv0


### PR DESCRIPTION
## Description
When I was working with the RIP diagnostic in IDA it became quickly obvious that the diagnostic was multi-pass but only a single pass was accounted for in `n_e_line`. This PR adds a simple factor of 2 to integrate over both passes.

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing

Validated against imas_composer, which was used to cross-check the consistency of the CO2 and RIP interferometers in IDA.

## Pre-Merge Checklist

- [ ] OMFIT has been tested with this OMAS version and you will create a PR on OMFIT that updates the OMAS submodule once this has been merged.
- [ ] Version number has been incremented if this is a major modification or important bug fix
  - To increment the version: Edit the version number in `omas/version` file
  - Follow semantic versioning: MAJOR.MINOR.PATCH (e.g., `0.94.2` → `0.94.3` for bug fixes, `0.94.2` → `0.95.0` for new features)
  - A GitHub release will be automatically created when this PR is merged if the version number has changed

## Additional Notes

<!-- Any additional information that reviewers should know -->
