### PR TITLE
Add jtor to omas viewer plot

### DIFF
--- a/omas/machine_mappings/_efit.json
+++ b/omas/machine_mappings/_efit.json
@@ -214,6 +214,9 @@
  "equilibrium.time_slice.:.constraints.ip.chi_squared": {
   "PYTHON": "scalar_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'ip', 'PLASMA', 'SIGPASMA', 'FWTPASMA', 'CPASMA', 'CHIPASMA', {EFIT_run_id!r})"
  },
+ "equilibrium.time_slice.:.constraints.bpol_probe.:": {
+  "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'bpol_probe', 'EXPMPI', 'SIGMPI', 'FWTMP2', 'CMPR2', 'SAIMPI', {EFIT_run_id!r})"
+ },
  "equilibrium.time_slice.:.constraints.bpol_probe.:.measured": {
   "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'bpol_probe', 'EXPMPI', 'SIGMPI', 'FWTMP2', 'CMPR2', 'SAIMPI', {EFIT_run_id!r})"
  },
@@ -244,6 +247,9 @@
  "equilibrium.time_slice.:.constraints.diamagnetic_flux.chi_squared": {
   "PYTHON": "scalar_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'diamagnetic_flux', 'DIAMAG', 'SIGDIA', 'FWTDIA', 'CDFLUX', 'CHIDFLUX', {EFIT_run_id!r})"
  },
+ "equilibrium.time_slice.:.constraints.flux_loop.:": {
+  "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'flux_loop', 'SILOPT', 'SIGSIL', 'FWTSI', 'CSILOP', 'SAISIL', {EFIT_run_id!r})"
+ },
  "equilibrium.time_slice.:.constraints.flux_loop.:.measured": {
   "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'flux_loop', 'SILOPT', 'SIGSIL', 'FWTSI', 'CSILOP', 'SAISIL', {EFIT_run_id!r})"
  },
@@ -258,6 +264,9 @@
  },
  "equilibrium.time_slice.:.constraints.flux_loop.:.chi_squared": {
   "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'flux_loop', 'SILOPT', 'SIGSIL', 'FWTSI', 'CSILOP', 'SAISIL', {EFIT_run_id!r})"
+ },
+ "equilibrium.time_slice.:.constraints.mse_polarisation_angle.:": {
+  "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'mse_polarisation_angle', 'TANGAM', 'SIGGAM', 'FWTGAM', 'CMGAM', 'CHIGAM', {EFIT_run_id!r})"
  },
  "equilibrium.time_slice.:.constraints.mse_polarisation_angle.:.measured": {
   "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'mse_polarisation_angle', 'TANGAM', 'SIGGAM', 'FWTGAM', 'CMGAM', 'CHIGAM', {EFIT_run_id!r})"
@@ -274,6 +283,9 @@
  "equilibrium.time_slice.:.constraints.mse_polarisation_angle.:.chi_squared": {
   "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'mse_polarisation_angle', 'TANGAM', 'SIGGAM', 'FWTGAM', 'CMGAM', 'CHIGAM', {EFIT_run_id!r})"
  },
+ "equilibrium.time_slice.:.constraints.pf_current.:": {
+  "PYTHON": "concat_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'pf_current', ['ECCURT','FCCURT'], ['SIGECC','SIGFCC'], ['FWTEC','FWTFC'], ['CECURR','CCBRSP'], ['CHIECC','CHIFCC'], {EFIT_run_id!r})"
+ },
  "equilibrium.time_slice.:.constraints.pf_current.:.measured": {
   "PYTHON": "concat_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'pf_current', ['ECCURT','FCCURT'], ['SIGECC','SIGFCC'], ['FWTEC','FWTFC'], ['CECURR','CCBRSP'], ['CHIECC','CHIFCC'], {EFIT_run_id!r})"
  },
@@ -288,6 +300,9 @@
  },
  "equilibrium.time_slice.:.constraints.pf_current.:.chi_squared": {
   "PYTHON": "concat_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'pf_current', ['ECCURT','FCCURT'], ['SIGECC','SIGFCC'], ['FWTEC','FWTFC'], ['CECURR','CCBRSP'], ['CHIECC','CHIFCC'], {EFIT_run_id!r})"
+ },
+  "equilibrium.time_slice.:.constraints.pressure.:": {
+  "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'pressure', 'PRESSR', 'SIGPRE', 'FWTPRE', 'CPRESS', 'SAIPRE', {EFIT_run_id!r})"
  },
  "equilibrium.time_slice.:.constraints.pressure.:.measured": {
   "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'pressure', 'PRESSR', 'SIGPRE', 'FWTPRE', 'CPRESS', 'SAIPRE', {EFIT_run_id!r})"
@@ -306,6 +321,9 @@
  },
  "equilibrium.time_slice.:.constraints.pressure.:.position.psi": {
   "PYTHON": "constraint_psi_to_real_psi(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'pressure', 'RPRESS', EFIT_run_id={EFIT_run_id!r})"
+ },
+ "equilibrium.time_slice.:.constraints.j_tor.:": {
+  "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'j_tor', 'VZEROJ', EFIT_run_id={EFIT_run_id!r})"
  },
  "equilibrium.time_slice.:.constraints.j_tor.:.measured": {
   "PYTHON": "vector_constraint_data(ods, {machine!r}, {pulse}, {EFIT_tree!r}, 'j_tor', 'VZEROJ', EFIT_run_id={EFIT_run_id!r})"

--- a/omas/machine_mappings/d3d.json
+++ b/omas/machine_mappings/d3d.json
@@ -953,6 +953,9 @@
  "wall.description_2d.:.limiter.unit.:.outline.z": {
   "PYTHON": "wall(ods, {pulse}, {EFIT_tree!r}, {EFIT_run_id!r})"
  },
+ "wall.ids_properties.homogeneous_time": {
+  "PYTHON": "wall(ods, {pulse}, {EFIT_tree!r}, {EFIT_run_id!r})"
+ },
  "wall.time": {
   "PYTHON": "wall(ods, {pulse}, {EFIT_tree!r}, {EFIT_run_id!r})"
  }

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -1099,8 +1099,8 @@ def equilibrium_summary(ods, time_index=None, time=None, fig=None, ggd_points_tr
                                             ods[f"equilibrium.time_slice.{time_index}.constraints.j_tor.:.position.psi"])
             plot_1d_equilbrium_quantity(ax, x, eq["profiles_1d.j_tor"] / 1.e6,
                                         xName, r"$\langle j_\mathrm{tor} / R \rangle$ [MA m$^{-2}$]", 
-                                        r"$j_\mathrm{tor}$", visible_x=omas_viewer, linestyle="None", marker=".",
-                                        color='red')
+                                        r"$j_\mathrm{tor}$", visible_x=omas_viewer, linestyle="solid",
+                                        color='blue')
             plot_1d_equilbrium_quantity(ax, x_constr, eq["constraints.j_tor.:.measured"] / 1.e6,
                                         xName, r"$\langle j_\mathrm{tor, meas} / R \rangle$ [MA m$^{-2}$]", 
                                         r"$j_\mathrm{tor}$", visible_x=omas_viewer, linestyle="None", marker=".",

--- a/omas/omas_plot.py
+++ b/omas/omas_plot.py
@@ -1097,8 +1097,12 @@ def equilibrium_summary(ods, time_index=None, time=None, fig=None, ggd_points_tr
             ax = cached_add_subplot(fig, axs, 2, 3, 3, sharex=ax)
             x_constr = remap_flux_coordinates(ods, time_index, "psi", raw_xName, 
                                             ods[f"equilibrium.time_slice.{time_index}.constraints.j_tor.:.position.psi"])
-            plot_1d_equilbrium_quantity(ax, x_constr, eq["constraints.j_tor.:.measured"] / 1.e6,
+            plot_1d_equilbrium_quantity(ax, x, eq["profiles_1d.j_tor"] / 1.e6,
                                         xName, r"$\langle j_\mathrm{tor} / R \rangle$ [MA m$^{-2}$]", 
+                                        r"$j_\mathrm{tor}$", visible_x=omas_viewer, linestyle="None", marker=".",
+                                        color='red')
+            plot_1d_equilbrium_quantity(ax, x_constr, eq["constraints.j_tor.:.measured"] / 1.e6,
+                                        xName, r"$\langle j_\mathrm{tor, meas} / R \rangle$ [MA m$^{-2}$]", 
                                         r"$j_\mathrm{tor}$", visible_x=omas_viewer, linestyle="None", marker=".",
                                         color='red')
         except ValueError:


### PR DESCRIPTION
## Description
Adds `j_tor` to the equilibrium summary shot. It also fixes a bug where constraints could not be loaded due to missing structure nodes in `_efit.json`. The downside is that the added structure nodes duplicate the loading of the constraint data making the plot glacially slow.

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing
See the plot #406 

## Pre-Merge Checklist

- [ ] OMFIT has been tested with this OMAS version and you will create a PR on OMFIT that updates the OMAS submodule once this has been merged.
- [ ] Version number has been incremented if this is a major modification or important bug fix
  - To increment the version: Edit the version number in `omas/version` file
  - Follow semantic versioning: MAJOR.MINOR.PATCH (e.g., `0.94.2` → `0.94.3` for bug fixes, `0.94.2` → `0.95.0` for new features)
  - A GitHub release will be automatically created when this PR is merged if the version number has changed

## Additional Notes

<!-- Any additional information that reviewers should know -->
