### PR TITLE
Extend the time before stale bot acts

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "30 1 * * *"
+  - cron: "30 7 * * 1-5"
 
 jobs:
   stale:
@@ -14,18 +14,18 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Do not mark issues with these labels
-        exempt-issue-labels: "bug,enhancement,WIP"
+        exempt-issue-labels: "bug,enhancement,WIP,wontfix"
         stale-issue-message: >
-            This issue has not seen any activity in the past 60 days.
-            It is now marked as stale and will be closed in 7 days if
+            This issue has not seen any activity in the past 180 days.
+            It is now marked as stale and will be closed in 180 days if
             no further activity is registered.
         # Do not mark PRs with these labels
-        exempt-pr-labels: 'WIP,Blocked-by-other-PR'
+        exempt-pr-labels: 'bug,enhancement,WIP,Blocked-by-other-PR'
         stale-pr-message: >
-            This PR has not seen any activity in the past 60 days.
-            It is now marked as stale and will be closed in 7 days if
+            This PR has not seen any activity in the past 180 days.
+            It is now marked as stale and will be closed in 180 days if
             no further activity is registered.
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
-        days-before-stale: 60
-        days-before-close: 21
+        days-before-stale: 180
+        days-before-close: 180


### PR DESCRIPTION
## Description

The time frame that stale bot waits before labeling and closing issues and PRs is increased to half a year. This reflects the irregular development that this repo sees.

There appears to be a pretty strong consensus that the stale bot does more harm than good, so I'm beginning to come around to the idea that it may be worth removing completely. I'd welcome any strong opinions on its application to this repo. The changes in this PR could be seen as a compromise or stepping stone between the current bot behavior and complete removal.
https://www.reddit.com/r/programming/comments/sh6a1t/github_stale_bot_considered_harmful/

Also making some tweaks to when the stale bot activates (no one needs to get a notification at 1:30am on a Sunday) and the labels that will deactivate it.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Other (please describe): GitHub Actions

## Testing

N/R only activates after merging

## Pre-Merge Checklist

- [ ] OMFIT has been tested with this OMAS version and you will create a PR on OMFIT that updates the OMAS submodule once this has been merged.
- [ ] Version number has been incremented if this is a major modification or important bug fix
  - To increment the version: Edit the version number in `omas/version` file
  - Follow semantic versioning: MAJOR.MINOR.PATCH (e.g., `0.94.2` → `0.94.3` for bug fixes, `0.94.2` → `0.95.0` for new features)
  - A GitHub release will be automatically created when this PR is merged if the version number has changed